### PR TITLE
Run docker without 'root'

### DIFF
--- a/docs/user-guide/install/docker.md
+++ b/docs/user-guide/install/docker.md
@@ -62,6 +62,17 @@ Where:
 - `restart: always`        - automatically start ThingsBoard in case of system reboot and restart in case of failure.
 - `image: thingsboard/tb-postgres`          - docker image, can be also `thingsboard/tb-cassandra` or `thingsboard/tb`
 
+
+Before starting Docker container run following commands to create a directory for storing data and logs and then change its owner to docker container user,
+to be able to change user, **chown** command is used, which requires sudo permissions (command will request password for a sudo access):
+
+```
+$ mkdir -p ~/.mytb-data && sudo chown -R 799:799 ~/.mytb-data
+$ mkdir -p ~/.mytb-logs && sudo chown -R 799:799 ~/.mytb-logs
+```
+
+**NOTE**: replace directory `~/.mytb-data` and `~/.mytb-logs` with directories you're planning to used in `docker-compose.yml`. 
+
 Execute the following command to up this docker compose directly:
 
 **NOTE**: For running docker compose commands you have to be in a directory with docker-compose.yml file. 
@@ -90,7 +101,7 @@ In case of any issues you can examine service logs for errors.
 For example to see ThingsBoard node logs execute the following command:
 
 ```
-docker-compose logs -f mytbpe
+docker-compose logs -f mytb
 ```
 {: .copy-code}
 
@@ -124,6 +135,9 @@ docker-compose up
 **NOTE**: if you use different database change image name in all commands from `thingsboard/tb-postgres` to `thingsboard/tb-cassandra` or `thingsboard/tb` correspondingly.
  
 **NOTE**: replace host's directory `~/.mytb-data` with directory used during container creation. 
+
+**NOTE**: if you have used one database and want to try another one, then remove the current docker container using `docker-compose rm` command and use different directory for `~/.mytb-data` in `docker-compose.yml`.
+ 
 
 ## Troubleshooting
 

--- a/docs/user-guide/install/pe/docker.md
+++ b/docs/user-guide/install/pe/docker.md
@@ -41,6 +41,18 @@ RabbitMQ <small>(for small on-prem installations)</small>%,%rabbitmq%,%templates
 
 {% include content-toggle.html content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}  
 
+Where: 
+    
+- `PUT_YOUR_LICENSE_SECRET_HERE` - placeholder for your license secret obtained on the first step;    
+- `8080:9090`            - connect local port 8080 to exposed internal HTTP port 9090;
+- `1883:1883`            - connect local port 1883 to exposed internal MQTT port 1883;   
+- `5683:5683`            - connect local port 5683 to exposed internal COAP port 5683; 
+- `~/.mytbpe-data:/data`   - mounts the host's dir `~/.mytbpe-data` to ThingsBoard DataBase data directory;
+- `~/.mytbpe-logs:/var/log/thingsboard`   - mounts the host's dir `~/.mytbpe-logs` to ThingsBoard logs directory;
+- `mytbpe`             - friendly local name of this machine;
+- `restart: always`        - automatically start ThingsBoard in case of system reboot and restart in case of failure.;
+- `store/thingsboard/tb-pe:3.0.1PE`          - docker image.
+
 ## Step 3. Running
 
 Make sure your have [logged in](https://docs.docker.com/engine/reference/commandline/login/) to docker hub using command line.
@@ -54,18 +66,6 @@ docker-compose pull
 docker-compose up
 ```
 {: .copy-code}
-
-Where: 
-    
-- `PUT_YOUR_LICENSE_SECRET_HERE` - placeholder for your license secret obtained on the first step;    
-- `8080:9090`            - connect local port 8080 to exposed internal HTTP port 9090;
-- `1883:1883`            - connect local port 1883 to exposed internal MQTT port 1883;   
-- `5683:5683`            - connect local port 5683 to exposed internal COAP port 5683; 
-- `~/.mytbpe-data:/data`   - mounts the host's dir `~/.mytbpe-data` to ThingsBoard DataBase data directory;
-- `~/.mytbpe-logs:/var/log/thingsboard`   - mounts the host's dir `~/.mytbpe-logs` to ThingsBoard logs directory;
-- `mytbpe`             - friendly local name of this machine;
-- `restart: always`        - automatically start ThingsBoard in case of system reboot and restart in case of failure.;
-- `store/thingsboard/tb-pe:3.0.1PE`          - docker image.
     
 After executing this command you can open `http://{your-host-ip}:8080` in you browser (for ex. `http://localhost:8080`). You should see ThingsBoard login page.
 Use the following default credentials:

--- a/docs/user-guide/install/pe/docker.md
+++ b/docs/user-guide/install/pe/docker.md
@@ -55,6 +55,16 @@ Where:
 
 ## Step 3. Running
 
+Before starting Docker container run following commands to create a directory for storing data and logs and then change its owner to docker container user,
+to be able to change user, **chown** command is used, which requires sudo permissions (command will request password for a sudo access):
+
+```
+$ mkdir -p ~/.mytbpe-data && sudo chown -R 799:799 ~/.mytbpe-data
+$ mkdir -p ~/.mytbpe-logs && sudo chown -R 799:799 ~/.mytbpe-logs
+```
+
+**NOTE**: replace directory `~/.mytbpe-data` and `~/.mytbpe-logs` with directories you're planning to used in `docker-compose.yml`. 
+
 Make sure your have [logged in](https://docs.docker.com/engine/reference/commandline/login/) to docker hub using command line.
 
 Execute the following command to up this docker compose directly:


### PR DESCRIPTION
Instructions to run docker (tb, tb-postgres and tb-cassandra) on Linux without root access