### PR TITLE
Aws doc cloud

### DIFF
--- a/_data/guides-data.yml
+++ b/_data/guides-data.yml
@@ -84,6 +84,12 @@
       keywords: install cluster
       video: false
       pe: false
+    - path: /docs/user-guide/install/aws/
+      title: AWS cluster setup
+      subtitle: Learn how to setup ThingsBoard cluster on AWS infrastructure.
+      keywords: install cluster aws
+      video: false
+      pe: false
     - path: /docs/user-guide/install/cluster/docker-compose-setup/
       title: Cluster setup with Docker Compose
       subtitle: Learn how to setup ThingsBoard cluster with Docker Compose.

--- a/_data/installation.yml
+++ b/_data/installation.yml
@@ -37,6 +37,8 @@ toc:
     path: /docs/user-guide/install/building-from-source/
   - title: Cluster setup
     path: /docs/user-guide/install/cluster-setup/
+  - title: AWS cluster setup
+    path: /docs/user-guide/install/aws/
   - title: Cluster setup with Docker Compose
     path: /docs/user-guide/install/cluster/docker-compose-setup/
   - title: Cluster setup with Kubernetes on Minikube


### PR DESCRIPTION
Affected pages:
https://thingsboard.io/docs/user-guide/install/aws/
https://thingsboard.io//docs/user-guide/install/cluster/aws-cluster-setup/
https://thingsboard.io//docs/user-guide/install/cluster/aws-self-hosted-setup/
https://thingsboard.io/docs/guides/
https://thingsboard.io/docs/installation/
https://thingsboard.io/docs/user-guide/install/installation-options/