### PR TITLE
fixed keygen.properties examples for SSL certificate generation

### DIFF
--- a/docs/user-guide/certificates.md
+++ b/docs/user-guide/certificates.md
@@ -21,7 +21,7 @@ Open the keygen.properties file, and update the values if needed:
 DOMAIN_SUFFIX="localhost"
 ORGANIZATIONAL_UNIT=ThingsBoard
 ORGANIZATION=ThingsBoard
-CITY=San Francisco
+CITY="San Francisco"
 STATE_OR_PROVINCE=CA
 TWO_LETTER_COUNTRY_CODE=US
 
@@ -37,6 +37,8 @@ CLIENT_KEY_PASSWORD=password
 
 CLIENT_KEY_ALIAS="clientalias"
 CLIENT_FILE_PREFIX="mqttclient"
+CLIENT_KEY_ALG="RSA"
+CLIENT_KEY_SIZE="2048"
 ```
 
 #### Run Client keygen script

--- a/docs/user-guide/mqtt-over-ssl.md
+++ b/docs/user-guide/mqtt-over-ssl.md
@@ -27,9 +27,10 @@ For example:
 
 ```bash
 DOMAIN_SUFFIX="$(hostname)"
+SUBJECT_ALTERNATIVE_NAMES="ip:127.0.0.1"
 ORGANIZATIONAL_UNIT=ThingsBoard
 ORGANIZATION=ThingsBoard
-CITY=San Francisco
+CITY="San Francisco"
 STATE_OR_PROVINCE=CA
 TWO_LETTER_COUNTRY_CODE=US
 
@@ -39,6 +40,8 @@ SERVER_KEY_PASSWORD=server_key_password
 SERVER_KEY_ALIAS="serveralias"
 SERVER_FILE_PREFIX="mqttserver"
 SERVER_KEYSTORE_DIR="/etc/thingsboard/conf/"
+SERVER_KEY_ALG="RSA"
+SERVER_KEY_SIZE="2048"
 
 CLIENT_KEYSTORE_PASSWORD=password
 CLIENT_KEY_PASSWORD=password
@@ -46,6 +49,8 @@ CLIENT_KEY_PASSWORD=password
 CLIENT_TRUSTSTORE="client_truststore"
 CLIENT_KEY_ALIAS="clientalias"
 CLIENT_FILE_PREFIX="mqttclient"
+CLIENT_KEY_ALG="RSA"
+CLIENT_KEY_SIZE="2048"
 ```
 
 where 


### PR DESCRIPTION
fixed an issue
![image](https://user-images.githubusercontent.com/79898499/109953178-61ccca00-7ce8-11eb-8007-dca6fafe91cd.png)

updated examples for SSL certificate generation according to the downloadable resource https://raw.githubusercontent.com/thingsboard/thingsboard/master/tools/src/main/shell/keygen.properties

affected pages:
https://thingsboard.io/docs/user-guide/certificates/
https://thingsboard.io/docs/user-guide/mqtt-over-ssl/