### PR TITLE
Add TimescaleDB extension installation instructions

### DIFF
--- a/_includes/templates/install/timescale-rhel-install.md
+++ b/_includes/templates/install/timescale-rhel-install.md
@@ -1,1 +1,10 @@
 Please refer to the official [TimescaleDB installation page](https://docs.timescale.com/latest/getting-started/installation/rhel-centos/installation-yum) on RHEL/CentOS distros and follow the instructions in accordance with your installed PostgreSQL version.
+
+After package installation, you need to create TimescaleDB extension in your ThingsBoard database:
+```bash
+sudo su - postgres
+psql -d thingsboard
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+\q
+#Then, press “Ctrl+D” to return to main user console.
+```

--- a/_includes/templates/install/timescale-ubuntu-install.md
+++ b/_includes/templates/install/timescale-ubuntu-install.md
@@ -1,1 +1,8 @@
 Please refer to the official [TimescaleDB installation page](https://docs.timescale.com/latest/getting-started/installation/ubuntu/installation-apt-ubuntu) on Ubuntu distros and follow the instructions in accordance with your installed PostgreSQL version.
+
+After package installation, you need to create TimescaleDB extension in your ThingsBoard database:
+```bash
+psql -U postgres -h localhost -d thingsboard
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+\q
+```

--- a/_includes/templates/install/timescale-windows-install.md
+++ b/_includes/templates/install/timescale-windows-install.md
@@ -1,1 +1,9 @@
 Please refer to the official [TimescaleDB installation page](https://docs.timescale.com/latest/getting-started/installation/windows/installation-windows) on Windows and follow the instructions in accordance with your installed PostgreSQL version.
+
+After package installation, you need to create TimescaleDB extension in your ThingsBoard database:
+1. Run PSQL console: Start Menu → PostgreSQL → SQL Shell (psql);
+2. Login to your "thingsboard" database;
+3. Run the command:
+```bash 
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+```


### PR DESCRIPTION
Previously, instruction for Timescale regarding extension installation was very subtle (you needed to find a post-install page, and it was unclear on how to do it on WIndows).