### PR TITLE
linkchecker docker run simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ Example:
 Use the following command to check the broken links.
 
 ```bash
-docker run -it --rm --network=host linkchecker/linkchecker http://0.0.0.0:4000/
+docker run -it --rm --network=host linkchecker/linkchecker --check-extern http://0.0.0.0:4000/
 ```

--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ Example:
 ```bash
 ./generate-previews.sh images/solution-templates *.png
 ```
+
+## Linkchecker
+
+Use the following command to check the broken links.
+
+```bash
+docker run -it --rm --network=host linkchecker/linkchecker http://0.0.0.0:4000/
+```

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,6 +7,6 @@
 Use the following command to check the broken links. 
 
 ```bash
-docker run -it --rm --network=host linkchecker/linkchecker http://0.0.0.0:4000/
+docker run -it --rm --network=host linkchecker/linkchecker --check-extern http://0.0.0.0:4000/
 ```
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,9 +4,9 @@
 
 ## Linkchecker
 
-Use the following command to check the broken links. Don't forget to substitute YOUR_IP with the internal IP address of your machine. 
+Use the following command to check the broken links. 
 
 ```bash
-docker run linkchecker/linkchecker http://YOUR_IP:4000/
+docker run -it --rm --network=host linkchecker/linkchecker http://0.0.0.0:4000/
 ```
 


### PR DESCRIPTION
## PR Checklist

- [x] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links.

```bash
docker run -it --rm --network=host linkchecker/linkchecker --check-extern http://0.0.0.0:4000/
```

