### PR TITLE
fix MQTT firmware API reference doc

### DIFF
--- a/_includes/docs/reference/mqtt-api.md
+++ b/_includes/docs/reference/mqtt-api.md
@@ -327,13 +327,15 @@ Where
 When the MQTT device receives updates for fw_title and fw_version shared attributes, it has to send PUBLISH message to
 
 ```bash
-v2/fw/request/${requestId}/chunk/${chunk} 
+v2/fw/request/${requestId}/chunk/${chunkIndex} 
 ```
 {: .copy-code}
 
 Where
+
 **${requestId}** - number corresponding to the number of firmware updates. The ${requestId} has to be different for each firmware update.  
-**${chunk}** - the size of the firmware in bytes. The chunks are counted from 0. The device must increment the chunk index for each request until the chunk size is zero.
+**${chunkIndex}** - number corresponding to the index of firmware chunks. The ${chunkID} are counted from 0. The device must increment the chunk index for each request until the received chunk size is zero.  
+And the MQTT payload should be the size of the firmware chunk in bytes.
 
 For each new firmware update, you need to change the request ID and subscribe to 
 


### PR DESCRIPTION
I think there is an error in the [MQTT firmware API reference](https://github.com/thingsboard/thingsboard.github.io/blob/007422a3c3585529d2d743cc8885ecc0b05e510b/_includes/docs/reference/mqtt-api.md?plain=1#L313). Judging from the [python MQTT firmware example](https://github.com/thingsboard/thingsboard.github.io/blob/master/docs/user-guide/resources/firmware/mqtt_firmware_client.py), the firmware chunk request's topic should contain the chunk index and its payload should be the chunk size.

