### PR TITLE
fixed Reports parameters in Configuration properties documentation PE

### DIFF
--- a/_includes/docs/user-guide/install/platform-integrations-and-reports-parameters.md
+++ b/_includes/docs/user-guide/install/platform-integrations-and-reports-parameters.md
@@ -89,7 +89,25 @@
           <td>reports.server.endpointUrl</td>
           <td>REPORTS_SERVER_ENDPOINT_URL</td>
           <td>http://localhost:8383</td>
-          <td>Enable/disable integrations statistics</td>
+          <td></td>
+      </tr>
+      <tr>
+          <td>reports.rate_limits.enabled</td>
+          <td>REPORTS_TENANT_RATE_LIMITS_ENABLED</td>
+          <td>false</td>
+          <td>Enable/disable reports tenant rate limits</td>
+      </tr>
+      <tr>
+          <td>reports.rate_limits.configuration</td>
+          <td>REPORTS_TENANT_RATE_LIMITS_CONFIGURATION</td>
+          <td>5:300</td>
+          <td></td>
+      </tr>
+      <tr>
+          <td>reports.scheduler.min_interval</td>
+          <td>REPORTS_SCHEDULER_MIN_INTERVAL_IN_SEC</td>
+          <td>60</td>
+          <td>Minimum interval between subsequent scheduler events. Applicable for timer based events</td>
       </tr>
     </tbody>
 </table>


### PR DESCRIPTION
added new parameters in "Reports parameters" in "Configuration properties" documentation PE:
reports.rate_limits.enabled: false
reports.rate_limits.configuration: 5:300
reports.scheduler.min_interval: 60


## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run -it --rm --network=host linkchecker/linkchecker --check-extern http://0.0.0.0:4000/
```

