### PR TITLE
Explain how to configure the Git repo to build Docker image on Window

### DIFF
--- a/docs/user-guide/install/building-from-source.md
+++ b/docs/user-guide/install/building-from-source.md
@@ -35,6 +35,18 @@ Use java installation [instructions](#java) to fix this.
 
 #### Source code
 
+{% capture windows_line_endings %}
+**NOTE: Building Docker image on Windows machine**
+
+To build Docker image certain scripts, configuration files and sources what will be a part of the Docker image must have **LF** line endings.
+So before cloning the repo set to _input_ the Git [core.autocrlf](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf) configuration option.
+
+For example, to set *core.autocrlf* globally:
+
+`git config --global core.autocrlf input`{:.language-bash}
+{% endcapture %}
+{% include templates/warn-banner.md content=windows_line_endings %}
+
 You can clone source code of the project from the official [github repo](https://github.com/thingsboard/thingsboard).
 
 ```bash
@@ -52,6 +64,8 @@ mvn clean install -DskipTests
 ```
 
 #### Build local docker images
+
+{% include templates/warn-banner.md content=windows_line_endings %}
 
 Make sure that [Docker](https://docs.docker.com/engine/install/) is installed.
 
@@ -106,4 +120,13 @@ rm -rf ui-ngx/node_modules
 - build in parallel, format headers, build docker images
 ```bash
 mvn -T 0.8C license:format clean install -DskipTests -Ddockerfile.skip=false
+```
+
+#### Build and runtime errors
+
+- If you see such errors when running locally-built Docker image, re-clone the repo with **LF** [file ending](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf) and re-build the image.
+To fix this read [Source code](#source-code) section.
+
+```bash
+Standard_init_linux.go:175 exec user process caused no such file
 ```


### PR DESCRIPTION
The root cause is file line ending. Windows uses CRLF, Unix - LF.
My Git client automatically switches line endings while cloning or committing sources, but to locally build Docker image some sources need to have LF ending otherwise TB will not be able to start.

And please don't leave [your Dart client](https://github.com/thingsboard/dart_thingsboard_client) alone)))