### PR TITLE
fixed description: m6a.2xlarge: 8 vCPU, 32GB RAM

### DIFF
--- a/_includes/docs/reference/performance-aws-instances.md
+++ b/_includes/docs/reference/performance-aws-instances.md
@@ -40,9 +40,9 @@ The test scenarios differ in the number of connected devices, messages per secon
 |---------------------------|---------|------------------------|----------------------------------------|------------|------------------------|-----------|------------|
 | [Scenario A](#scenario-a) | 5K      | 1K                     | t3.medium: 2 burstable vCPU, 4GB RAM | in-memory  | PostgreSQL             | 27%       | 800        |
 | [Scenario B](#scenario-b) | 5K      | 15K                    | m6a.large: 2 vCPU, 8GB RAM            | Kafka      | PostgreSQL             | 95%       | 850        |
-| [Scenario C](#scenario-c) | 25K     | 30K                    | m6a.2xlarge: 4 vCPU, 16GB RAM         | Kafka      | PostgreSQL + Cassandra | 75%       | 200        |
-| [Scenario D](#scenario-d) | 100K    | 15K                    | m6a.2xlarge: 4 vCPU, 16GB RAM         | Kafka      | PostgreSQL + Cassandra | 71%       | 700        |
-| [Scenario E](#scenario-e) | 100K    | 30K                    | m6a.2xlarge: 4 vCPU, 16GB RAM         | Kafka      | PostgreSQL + Cassandra | 95%       | 240        |
+| [Scenario C](#scenario-c) | 25K     | 30K                    | m6a.2xlarge: 8 vCPU, 32GB RAM         | Kafka      | PostgreSQL + Cassandra | 75%       | 200        |
+| [Scenario D](#scenario-d) | 100K    | 15K                    | m6a.2xlarge: 8 vCPU, 32GB RAM         | Kafka      | PostgreSQL + Cassandra | 71%       | 700        |
+| [Scenario E](#scenario-e) | 100K    | 30K                    | m6a.2xlarge: 8 vCPU, 32GB RAM         | Kafka      | PostgreSQL + Cassandra | 95%       | 240        |
 
 [comment]: <> ( To format table as markdown, please use the online table generator https://www.tablesgenerator.com/markdown_tables )
 


### PR DESCRIPTION

This is the minor fix of the m6a.2xlarge instance in the summary table

Affected page: https://thingsboard.io/docs/reference/performance-aws-instances/

## PR Checklist

- [x] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run -it --rm --network=host linkchecker/linkchecker --check-extern http://0.0.0.0:4000/
```

