### PR TITLE
[3.5] implement cleanup event by TTL for audit log

### DIFF
--- a/_includes/docs/user-guide/install/config.md
+++ b/_includes/docs/user-guide/install/config.md
@@ -1038,6 +1038,24 @@ The parameters are grouped by system components. The list contains the name (add
             <td>Parameter to specify how often TTL(Time To Live) will be checked.Number of milliseconds. The current value corresponds to two hours</td>
         </tr>
         <tr>
+            <td>sql.ttl.audit_log.enabled</td>
+            <td>SQL_TTL_AUDIT_LOG_ENABLED</td>
+            <td>true</td>
+            <td>Enable/disable TTL(Time To Live) for audit log events</td>
+        </tr>
+        <tr>
+            <td>sql.ttl.audit_log.events_ttl</td>
+            <td>SQL_TTL_AUDIT_LOG_EXECUTION_INTERVAL</td>
+            <td>86400000</td>
+            <td>Number of milliseconds. The current value corresponds to one day</td>
+        </tr>
+        <tr>
+            <td>sql.ttl.audit_log.execution_interval_ms</td>
+            <td>SQL_TTL_AUDIT_LOG_EVENTS_TTL</td>
+            <td>2628000</td>
+            <td>Number of seconds. The current value corresponds to one month</td>
+        </tr>
+        <tr>
             <td>sql.relations.max_level</td>
             <td>SQL_RELATIONS_MAX_LEVEL</td>
             <td>50</td>


### PR DESCRIPTION
add SQL configuration parameters for cleanup audit log events by TTL
added: 
- sql.ttl.audit_log.enabled
- sql.ttl.audit_log.events_ttl
- sql.ttl.audit_log.execution_interval_ms

![image](https://user-images.githubusercontent.com/70033193/187230197-68eda382-5e3b-445b-a9d4-ff4b981a2b16.png)


## PR Checklist

- [x] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

