### PR TITLE
Fix for provisioning example clients

### DIFF
--- a/_includes/templates/provisioning/coap-access-token-credentials-type.md
+++ b/_includes/templates/provisioning/coap-access-token-credentials-type.md
@@ -33,10 +33,10 @@ Provisioning response example:
 
 #### Sample script
 
-To communicate with ThingsBoard we will use CoAPthon3 module, so we should install it:
+To communicate with ThingsBoard we will use asyncio and aiocoap modules, so we should install it:
 
 ```bash
-pip3 install coapthon3 --user
+pip3 install asyncio aiocoap --user
 ```
 {: .copy-code}
 
@@ -58,9 +58,16 @@ python3 device-provision-example.py
 The script source code: 
 
 ```python
+import logging
+import asyncio
 
-from coapthon.client.helperclient import HelperClient
+from aiocoap import Context, Message, Code
 from json import loads, dumps
+
+THINGSBOARD_HOST = ""
+THINGSBOARD_PORT = ""
+
+logging.basicConfig(level=logging.INFO)
 
 
 def collect_required_data():
@@ -95,12 +102,54 @@ to_publish = {
   }
 }
 
+
+async def process():
+    server_address = "coap://" + THINGSBOARD_HOST + ":" + str(THINGSBOARD_PORT)
+
+    client_context = await Context.create_client_context()
+    await asyncio.sleep(2)
+    try:
+        msg = Message(code=Code.POST, payload=str.encode(dumps(PROVISION_REQUEST)), uri=server_address+'/api/v1/provision')
+        request = client_context.request(msg)
+        try:
+            response = await asyncio.wait_for(request.response, 60000)
+        except asyncio.TimeoutError:
+            raise Exception("Request timed out!")
+
+        if response is None:
+            raise Exception("Response is empty!")
+
+        decoded_response = loads(response.payload)
+        logging.info("Received response: %s", decoded_response)
+        received_token = decoded_response.get("credentialsValue")
+        if received_token is not None:
+            msg = Message(code=Code.POST, payload=str.encode(dumps(to_publish)),
+                          uri=server_address+('/api/v1/%s/telemetry' % received_token))
+            request = client_context.request(msg)
+            try:
+                response = await asyncio.wait_for(request.response, 60000)
+            except asyncio.TimeoutError:
+                raise Exception("Request timed out!")
+
+            if response:
+                logging.info("[THINGSBOARD CLIENT] Response from Thingsboard.")
+                logging.info(response)
+            else:
+                raise Exception("[THINGSBOARD CLIENT] Cannot save telemetry with received credentials!")
+        else:
+            logging.error("Failed to get access token from response.")
+            logging.error(decoded_response.get("errorMsg"))
+    except Exception as e:
+        logging.error(e)
+    finally:
+        await client_context.shutdown()
+
 if __name__ == '__main__':
 
     config = collect_required_data()
 
     THINGSBOARD_HOST = config["host"]  # ThingsBoard instance host
-    THINGSBOARD_PORT = config["port"]  # ThingsBoard instance MQTT port
+    THINGSBOARD_PORT = config["port"]  # ThingsBoard instance port
 
     PROVISION_REQUEST = {"provisionDeviceKey": config["provision_device_key"],  # Provision device key, replace this value with your value from device profile.
                          "provisionDeviceSecret": config["provision_device_secret"],  # Provision device secret, replace this value with your value from device profile.
@@ -109,22 +158,8 @@ if __name__ == '__main__':
                          }
     if config.get("device_name") is not None:
         PROVISION_REQUEST["deviceName"] = config["device_name"]
-    client = HelperClient(server=(THINGSBOARD_HOST, THINGSBOARD_PORT))
-    response = client.post('/api/v1/provision', dumps(PROVISION_REQUEST))
-    client.stop()
-    decoded_response = loads(response.payload)
-    print("Received response: ")
-    print(decoded_response)
-    received_token = decoded_response.get("credentialsValue")
-    if received_token is not None:
-        thingsboardClient = HelperClient(server=(THINGSBOARD_HOST, THINGSBOARD_PORT))
-        response = thingsboardClient.post('/api/v1/%s/telemetry' % (received_token,), dumps(to_publish))
-        print("[THINGSBOARD CLIENT] Response from Thingsboard.")
-        print(response)
-        thingsboardClient.stop()
-    else:
-        print("Failed to get access token from response.")
-        print(decoded_response.get("errorMsg"))
+
+    asyncio.run(process())
 
 ```
 {: .copy-code}

--- a/_includes/templates/provisioning/coap-without-credentials-type.md
+++ b/_includes/templates/provisioning/coap-without-credentials-type.md
@@ -30,10 +30,10 @@ Provisioning response example:
 
 #### Sample script
 
-To communicate with ThingsBoard we will use CoAPthon3 module, so we should install it:
+To communicate with ThingsBoard we will use asyncio and aiocoap modules, so we should install it:
 
 ```bash
-pip3 install coapthon3 --user
+pip3 install asyncio aiocoap --user
 ```
 {: .copy-code}
 
@@ -55,9 +55,16 @@ python3 device-provision-example.py
 The script source code: 
 
 ```python
+import logging
+import asyncio
 
-from coapthon.client.helperclient import HelperClient
+from aiocoap import Context, Message, Code
 from json import loads, dumps
+
+THINGSBOARD_HOST = ""
+THINGSBOARD_PORT = ""
+
+logging.basicConfig(level=logging.INFO)
 
 
 def collect_required_data():
@@ -91,34 +98,62 @@ to_publish = {
   }
 }
 
+
+async def process():
+    server_address = "coap://" + THINGSBOARD_HOST + ":" + str(THINGSBOARD_PORT)
+
+    client_context = await Context.create_client_context()
+    await asyncio.sleep(2)
+    try:
+        msg = Message(code=Code.POST, payload=str.encode(dumps(PROVISION_REQUEST)), uri=server_address+'/api/v1/provision')
+        request = client_context.request(msg)
+        try:
+            response = await asyncio.wait_for(request.response, 60000)
+        except asyncio.TimeoutError:
+            raise Exception("Request timed out!")
+
+        if response is None:
+            raise Exception("Response is empty!")
+
+        decoded_response = loads(response.payload)
+        logging.info("Received response: %s", decoded_response)
+        received_token = decoded_response.get("credentialsValue")
+        if received_token is not None:
+            msg = Message(code=Code.POST, payload=str.encode(dumps(to_publish)),
+                          uri=server_address+('/api/v1/%s/telemetry' % received_token))
+            request = client_context.request(msg)
+            try:
+                response = await asyncio.wait_for(request.response, 60000)
+            except asyncio.TimeoutError:
+                raise Exception("Request timed out!")
+
+            if response:
+                logging.info("[THINGSBOARD CLIENT] Response from Thingsboard.")
+                logging.info(response)
+            else:
+                raise Exception("[THINGSBOARD CLIENT] Cannot save telemetry with received credentials!")
+        else:
+            logging.error("Failed to get access token from response.")
+            logging.error(decoded_response.get("errorMsg"))
+    except Exception as e:
+        logging.error(e)
+    finally:
+        await client_context.shutdown()
+
 if __name__ == '__main__':
 
     config = collect_required_data()
 
     THINGSBOARD_HOST = config["host"]  # ThingsBoard instance host
-    THINGSBOARD_PORT = config["port"]  # ThingsBoard instance MQTT port
+    THINGSBOARD_PORT = config["port"]  # ThingsBoard instance port
 
     PROVISION_REQUEST = {"provisionDeviceKey": config["provision_device_key"],  # Provision device key, replace this value with your value from device profile.
                          "provisionDeviceSecret": config["provision_device_secret"],  # Provision device secret, replace this value with your value from device profile.
                          }
     if config.get("device_name") is not None:
         PROVISION_REQUEST["deviceName"] = config["device_name"]
-    client = HelperClient(server=(THINGSBOARD_HOST, THINGSBOARD_PORT))
-    response = client.post('/api/v1/provision', dumps(PROVISION_REQUEST))
-    client.stop()
-    decoded_response = loads(response.payload)
-    print("Received response: ")
-    print(decoded_response)
-    received_token = decoded_response.get("credentialsValue")
-    if received_token is not None:
-        thingsboardClient = HelperClient(server=(THINGSBOARD_HOST, THINGSBOARD_PORT))
-        response = thingsboardClient.post('/api/v1/%s/telemetry' % (received_token,), dumps(to_publish))
-        print("[THINGSBOARD CLIENT] Response from Thingsboard.")
-        print(response)
-        thingsboardClient.stop()
-    else:
-        print("Failed to get access token from response.")
-        print(decoded_response.get("errorMsg"))
+
+    asyncio.run(process())
 
 ```
 {: .copy-code}

--- a/_includes/templates/provisioning/http-access-token-credentials-type.md
+++ b/_includes/templates/provisioning/http-access-token-credentials-type.md
@@ -62,8 +62,8 @@ def collect_required_data():
     print("="*80, "\n\n", sep="")
     host = input("Please write your ThingsBoard \033[93murl\033[0m or leave it blank to use default (https://thingsboard.cloud): ")
     config["host"] = host if host else "https://thingsboard.cloud"
-    port = input("Please write your ThingsBoard \033[93mHTTP port\033[0m or leave it blank to use default (80): ")
-    config["port"] = int(port) if port else 80
+    port = input("Please write your ThingsBoard \033[93mHTTP port\033[0m or leave it blank to use default (443): ")
+    config["port"] = int(port) if port else 443
     config["provision_device_key"] = input("Please write \033[93mprovision device key\033[0m: ")
     config["provision_device_secret"] = input("Please write \033[93mprovision device secret\033[0m: ")
     config["token"] = input("Please write \033[93mdevice access token\033[0m: ")

--- a/_includes/templates/provisioning/http-without-credentials-type.md
+++ b/_includes/templates/provisioning/http-without-credentials-type.md
@@ -60,8 +60,8 @@ def collect_required_data():
     print("="*80, "\n\n", sep="")
     host = input("Please write your ThingsBoard \033[93mhost\033[0m or leave it blank to use default (https://thingsboard.cloud): ")
     config["host"] = host if host else "https://thingsboard.cloud"
-    port = input("Please write your ThingsBoard \033[93mHTTP port\033[0m or leave it blank to use default (80): ")
-    config["port"] = int(port) if port else 80
+    port = input("Please write your ThingsBoard \033[93mHTTP port\033[0m or leave it blank to use default (443): ")
+    config["port"] = int(port) if port else 443
     config["provision_device_key"] = input("Please write \033[93mprovision device key\033[0m: ")
     config["provision_device_secret"] = input("Please write \033[93mprovision device secret\033[0m: ")
     device_name = input("Please write \033[93mdevice name\033[0m or leave it blank to generate: ")


### PR DESCRIPTION
This PR contains small fixes for HTTP client (default port changed) and different library for python example scripts for device provisioning.

## PR Checklist

- [x] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

