### PR TITLE
Teltonika home link

### DIFF
--- a/_includes/partners.json
+++ b/_includes/partners.json
@@ -23,7 +23,7 @@
     "logo": "teltonika-networks.png",
     "links": {
       "Site": {
-        "href": "https://teltonika-networks.com/",
+        "href": "https://teltonika-networks.com/?utm_source=iotplatform&utm_medium=referral&utm_content=thingsboard",
         "target": "_blank"
       },
       "Integration guide": {


### PR DESCRIPTION
Changed Teltonika networks home URL

## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

