### PR TITLE
FIX: Entity type filter rule node image

### DIFF
--- a/_includes/docs/user-guide/rule-engine-2-0/ce-filter-nodes.md
+++ b/_includes/docs/user-guide/rule-engine-2-0/ce-filter-nodes.md
@@ -143,7 +143,7 @@ Checks that the entity type of the incoming message originator matches one of th
 
  * Originator types filter - list of entity types: Device, Asset, User, etc.
 
-![image](/images/user-guide/rule-engine-2-0/nodes/check-relation-configuration.png)
+![image](/images/user-guide/rule-engine-2-0/nodes/entity-type-configuration.png)
 
 **Output**
 


### PR DESCRIPTION
Replacing the wrong image to show the Entity type filter node config UI.

## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

