### PR TITLE
Fixed alignment of devices titles, temporary hidden filters on smaller screens

### DIFF
--- a/_includes/devicelibrary.html
+++ b/_includes/devicelibrary.html
@@ -148,11 +148,11 @@
 </section>
 
 <style>
-  @media screen and (max-width: 1280px) {
-    #top-spacer {
-        display: none;
-    }
-  }
+  /*@media screen and (max-width: 1280px) {*/
+  /*  #top-spacer {*/
+  /*      display: none;*/
+  /*  }*/
+  /*}*/
   .cse .gsc-control-cse, .gsc-control-cse {
     padding: 0;
   }

--- a/_includes/devicelibrary.html
+++ b/_includes/devicelibrary.html
@@ -148,11 +148,6 @@
 </section>
 
 <style>
-  /*@media screen and (max-width: 1280px) {*/
-  /*  #top-spacer {*/
-  /*      display: none;*/
-  /*  }*/
-  /*}*/
   .cse .gsc-control-cse, .gsc-control-cse {
     padding: 0;
   }

--- a/_includes/devices.liquid
+++ b/_includes/devices.liquid
@@ -13,8 +13,7 @@
                 {% for devicePage in devicesInCategoryList %}
                     <li class="device-guide-container">
                         <a href="{{ devicePage.url }}">
-                            <img class="device-guide-img"
-                                 src="/images/devices-library/{{ devicePage.deviceImageFileName }}">
+                            <img src="/images/devices-library/{{ devicePage.deviceImageFileName }}">
                             <div class="device-guide-text">
                                 <p class="device-guide-title">
                                     {{ devicePage.title | remove : "How to connect " | remove: " to ThingsBoard?"}}

--- a/_includes/docs/devices-library/index.md
+++ b/_includes/docs/devices-library/index.md
@@ -172,4 +172,4 @@ In case you wish to integrate existing **LoRaWAN, NB IoT, or SigFox** sensors in
 
 <br/>
 
-If you want to add your device to Devices Library, you can follow next [guidelines](/docs/{{page.docsPrefix}}devices-library/guidelines/).
+<a href="/docs/{{page.docsPrefix}}devices-library/guidelines/" class="n-button add-device">Add your device</a>

--- a/_layouts/devices-library-article.liquid
+++ b/_layouts/devices-library-article.liquid
@@ -224,12 +224,9 @@
                 }
             });
 
-            var allCodeBlocksElements = $(".language-cpp");
+            var allCodeBlocksElements = $(".highlighter-rouge");
             allCodeBlocksElements.each(function (i) {
                 var codeBlock = $(this);
-                if (!codeBlock.hasClass('highlighter-rouge')) {
-                    codeBlock = codeBlock.find('.highlighter-rouge');
-                }
                 var pre = codeBlock.find('pre').first();
                 if (pre.prop('scrollHeight') > 2775) {
                     codeBlock.find('.rouge-gutter').css("width", "60px");

--- a/_layouts/devices-library-article.liquid
+++ b/_layouts/devices-library-article.liquid
@@ -224,33 +224,69 @@
                 }
             });
 
-            var allCodeBlocksElements = $(".copy-code");
+            var allCodeBlocksElements = $(".language-cpp");
             allCodeBlocksElements.each(function (i) {
                 var codeBlock = $(this);
                 if (!codeBlock.hasClass('highlighter-rouge')) {
                     codeBlock = codeBlock.find('.highlighter-rouge');
                 }
-                codeBlock.each(function () {
-                    var block = codeBlock.find('pre.highlight > code .rouge-code');
-                    var currentId = "codeblock" + (i + 1);
-                    block.attr('id', currentId);
-                    var clipButton = $('<button class="clipboard-btn" data-clipboard-target="#' + currentId + '"><p>Copy to clipboard</p><div><img src="/images/copy-code-icon.svg" alt="Copy to clipboard"></div></button>');
-                    $(this).append(clipButton);
-                    var troyan = codeBlock.find('pre.highlight');
-                    var Tooltip = $('<div class="customTooltip"><div class="tooltipText">Copied!</div></div>');
-                    troyan.append(Tooltip);
-                    troyan.addClass('clipboard-btn');
-                    troyan.attr('data-clipboard-target', "#" + currentId);
-                    troyan.on('mouseleave', clearTooltip);
-                    troyan.on('blur', clearTooltip);
-                    troyan.on('click', function (e) {
-                        var el = $(e.currentTarget);
-                        if (el.hasClass('showTool')) {
-                            clearTooltip(e);
-                            troyan.attr('data-skip-tooltip', "true");
-                        }
+                var pre = codeBlock.find('pre').first();
+                if (pre.prop('scrollHeight') > 2775) {
+                    codeBlock.find('.rouge-gutter').css("width", "60px");
+                }
+                for (let className of codeBlock.attr('class').split(' ')) {
+                    let match = className.startsWith('expandable') ? className : null;
+                    if (match) {
+                        let rows = parseInt(match.split('-')[1]);
+                        let collapsedHeight = rows * 28 + 5;
+                        let expandedHeight = pre.prop('scrollHeight');
+
+                        pre.css('height', collapsedHeight + 'px');
+                        codeBlock.find('.highlight').first().css("margin-bottom", "45px");
+                        let button = $('<button class="expand-code-btn"><div class="collapsed"></div><p>expand</p></button>');
+                        button.on('click', function() {
+                            if (button.attr('data-expanded') === 'true') {
+                                pre.css('height', collapsedHeight + 'px');
+                                button.attr('data-expanded', 'false');
+                                button.find('p').text('expand');
+                                button.get(0).scrollIntoView({block: "center"});
+                                button.find('div').removeClass('expanded');
+                                button.find('div').addClass('collapsed');
+                            } else {
+                                pre.css('height', expandedHeight + 'px');
+                                button.attr('data-expanded', 'true');
+                                button.find('p').text('collapse');
+                                button.find('div').removeClass('collapsed');
+                                button.find('div').addClass('expanded');
+                            }
+                        })
+                        codeBlock.append(button);
+                        break;
+                    }
+                }
+                if (codeBlock.hasClass('copy-code')) {
+                    codeBlock.each(function () {
+                        var block = codeBlock.find('pre.highlight > code .rouge-code');
+                        var currentId = "codeblock" + (i + 1);
+                        block.attr('id', currentId);
+                        var clipButton = $('<button class="clipboard-btn" data-clipboard-target="#' + currentId + '"><p>Copy to clipboard</p><div><img src="/images/copy-code-icon.svg" alt="Copy to clipboard"></div></button>');
+                        $(this).append(clipButton);
+                        var troyan = codeBlock.find('pre.highlight');
+                        var Tooltip = $('<div class="customTooltip"><div class="tooltipText">Copied!</div></div>');
+                        troyan.append(Tooltip);
+                        troyan.addClass('clipboard-btn');
+                        troyan.attr('data-clipboard-target', "#" + currentId);
+                        troyan.on('mouseleave', clearTooltip);
+                        troyan.on('blur', clearTooltip);
+                        troyan.on('click', function (e) {
+                            var el = $(e.currentTarget);
+                            if (el.hasClass('showTool')) {
+                                clearTooltip(e);
+                                troyan.attr('data-skip-tooltip', "true");
+                            }
+                        });
                     });
-                });
+                }
             });
 
             var clipboard = new Clipboard('.noChars');

--- a/_layouts/devices-library-article.liquid
+++ b/_layouts/devices-library-article.liquid
@@ -146,7 +146,7 @@
 
 <section id="encyclopedia">
     {% if siteData[foundTOC].hidetoc != "true" and page.hidetoc != "true" %}
-        <div id="docsToc">
+        <div id="docsToc" style="background-color: rgba(0,0,0,0)">
             <div class="pi-accordion">
                 {% assign tree = siteData[foundTOC].toc %}{% include tree.html %}
             </div> <!-- /pi-accordion -->

--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -1680,6 +1680,7 @@ section
           transform: rotate(90deg)
 
 #device-filters
+  display: none
   position: relative
   z-index: 1
   margin-top: 130px
@@ -1703,7 +1704,6 @@ section
       font-size: 1.2em
       font-weight: 600
       line-height: 24px
-      margin-bottom: 12px
   .group
     padding-left: 20px
     .title
@@ -1739,6 +1739,7 @@ section
       .filter
         margin-left: 5px
         .filter-label
+          cursor: pointer
           color: #75767C
           line-height: 24px
         input[type=checkbox]

--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -1299,7 +1299,7 @@ section
         #search
           transition: 0ms
 
-  .copy-code
+  .copy-code, .language-cpp
     .highlight
       background: none!important
       .customTooltip
@@ -1365,6 +1365,32 @@ section
         padding: 10px
         img
           position: initial
+    button.expand-code-btn
+      position: absolute
+      bottom: -33px
+      right: 0
+      left: 0
+      margin-right: auto
+      margin-left: auto
+      display: flex
+      flex-direction: column
+      justify-content: center
+      align-items: center
+      color: #2a7dec
+      width: 130px
+      height: 30px
+      outline: none
+      div
+        width: 0
+        height: 0
+      div.collapsed
+        border-left: 20px solid transparent
+        border-right: 20px solid transparent
+        border-top: 13px solid #2a7dec
+      div.expanded
+        border-left: 20px solid transparent
+        border-right: 20px solid transparent
+        border-bottom: 13px solid #2a7dec
     &:hover
       cursor: pointer
       div.highlight

--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -1299,7 +1299,7 @@ section
         #search
           transition: 0ms
 
-  .copy-code, .language-cpp
+  .copy-code
     .highlight
       background: none!important
       .customTooltip
@@ -1365,32 +1365,6 @@ section
         padding: 10px
         img
           position: initial
-    button.expand-code-btn
-      position: absolute
-      bottom: -33px
-      right: 0
-      left: 0
-      margin-right: auto
-      margin-left: auto
-      display: flex
-      flex-direction: column
-      justify-content: center
-      align-items: center
-      color: #2a7dec
-      width: 130px
-      height: 30px
-      outline: none
-      div
-        width: 0
-        height: 0
-      div.collapsed
-        border-left: 20px solid transparent
-        border-right: 20px solid transparent
-        border-top: 13px solid #2a7dec
-      div.expanded
-        border-left: 20px solid transparent
-        border-right: 20px solid transparent
-        border-bottom: 13px solid #2a7dec
     &:hover
       cursor: pointer
       div.highlight

--- a/_sass/_code-styles.sass
+++ b/_sass/_code-styles.sass
@@ -10,6 +10,32 @@ code
 
 .highlighter-rouge
 	position: relative
+	button.expand-code-btn
+		position: absolute
+		bottom: -33px
+		right: 0
+		left: 0
+		margin-right: auto
+		margin-left: auto
+		display: flex
+		flex-direction: column
+		justify-content: center
+		align-items: center
+		color: #2a7dec
+		width: 130px
+		height: 30px
+		outline: none
+		div
+			width: 0
+			height: 0
+		div.collapsed
+			border-left: 20px solid transparent
+			border-right: 20px solid transparent
+			border-top: 13px solid #2a7dec
+		div.expanded
+			border-left: 20px solid transparent
+			border-right: 20px solid transparent
+			border-bottom: 13px solid #2a7dec
 
 div.highlight
 	margin-top: 12px

--- a/_sass/_desktop.sass
+++ b/_sass/_desktop.sass
@@ -63,9 +63,10 @@ $nav-buttons-margin-left: 24px
 					.item
 						display: inline-block
 		#device-filters
+			display: none
 			position: relative
 			margin-top: 124px
-			display: flex
+			//display: flex
 			flex-direction: row
 			justify-content: space-between
 			width: 100%
@@ -87,7 +88,6 @@ $nav-buttons-margin-left: 24px
 				.header
 					display: block
 					position: relative
-					margin-bottom: 24px
 			@media screen and (min-width: 1600px)
 				width: 358px
 		#docsContent

--- a/_sass/_desktop.sass
+++ b/_sass/_desktop.sass
@@ -66,7 +66,6 @@ $nav-buttons-margin-left: 24px
 			display: none
 			position: relative
 			margin-top: 124px
-			//display: flex
 			flex-direction: row
 			justify-content: space-between
 			width: 100%

--- a/_sass/_tablet.sass
+++ b/_sass/_tablet.sass
@@ -83,7 +83,6 @@ $ocean-nodes-padding-Y: 0px
 		position: relative
 		z-index: 1
 		margin-top: 124px
-		//display: flex
 		flex-direction: row
 		justify-content: space-between
 		width: 100%

--- a/_sass/_tablet.sass
+++ b/_sass/_tablet.sass
@@ -79,10 +79,11 @@ $ocean-nodes-padding-Y: 0px
 		padding-bottom: 0px
 
 	#device-filters
+		display: none
 		position: relative
 		z-index: 1
 		margin-top: 124px
-		display: flex
+		//display: flex
 		flex-direction: row
 		justify-content: space-between
 		width: 100%

--- a/docs/devices-library.sass
+++ b/docs/devices-library.sass
@@ -16,7 +16,7 @@
           line-height: 30px
           font-size: 18px
           vertical-align: middle
-          border: 1px solid #ebebeb
+          border: 1px solid #000
           background-color: transparent
           border-radius: 4px
           color: #212529
@@ -25,12 +25,12 @@
             color: #212529
             opacity: 0.6
           &:hover
-            border: 2px solid #000
+            border: 1px solid #000
             padding: 1px 15px
             cursor: pointer
           &:focus
             cursor: initial
-            border: 2px solid #2a7dec
+            border: 2px solid var(--tb-main-color)
             padding: 1px 15px
             color: #212529
             +placeholder
@@ -105,8 +105,9 @@
               display: block
               margin: 0 auto
               width: 50%
+              height: 120px
+              object-fit: scale-down
             .device-guide-text
-              margin: auto
               .device-guide-title
                 font-weight: 500
                 font-size: 18px
@@ -120,6 +121,14 @@
                 color: #212529
               .device-guide-keywords
                 display: none
+  .n-button.add-device
+    text-decoration: none
+    color: #fff
+    background-color: var(--tb-main-color)
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)
+    transition: all 0.3s cubic-bezier(.25,.8,.25,1)
+    &:hover
+      box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22)
 
 @media screen and (min-width: 750px)
   #docsContent


### PR DESCRIPTION
Added option to expand/collapse code blocks:

![image](https://user-images.githubusercontent.com/87172504/225668999-240f89a9-1f79-4128-b1a2-1211d53c1936.png)
 
Collapsed code:
![image](https://user-images.githubusercontent.com/87172504/225669169-26dde526-c2de-4f2d-a7dc-414b6500201f.png)

Expanded code:
![image](https://user-images.githubusercontent.com/87172504/225669403-bcea8eed-5c12-435e-a5bb-ad19daefe1d5.png)

