### PR TITLE
Remove edge related stuff from CE/PE TB docker installations

### DIFF
--- a/_includes/templates/install/docker/docker-create-folders-sudo-explained.md
+++ b/_includes/templates/install/docker/docker-create-folders-sudo-explained.md
@@ -1,11 +1,3 @@
 Run following commands, before starting docker container(s), to create folders for storing data and logs.
 These commands additionally will change owner of newly created folders to docker container user.
 To do this (to change user) **chown** command is used, and this command requires *sudo* permissions (command will request password for a *sudo* access):
-
-```
-mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
-mkdir -p ~/.mytb-edge-logs && sudo chown -R 799:799 ~/.mytb-edge-logs
-```
-{: .copy-code}
-
-**NOTE**: Replace directory **~/.mytb-edge-data** and **~/.mytb-edge-logs** with directories you’re planning to use in `docker-compose.yml`.

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -73,6 +73,14 @@ services:
 
 {% include templates/install/docker/docker-create-folders-sudo-explained.md %}
 
+```
+mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
+mkdir -p ~/.mytb-edge-logs && sudo chown -R 799:799 ~/.mytb-edge-logs
+```
+{: .copy-code}
+
+**NOTE**: Replace directory `~/.mytb-edge-data` and `~/.mytb-edge-logs` with directories you’re planning to use in `docker-compose.yml`.
+
 {% assign serviceName = "tbedge" %}
 {% include templates/install/docker/docker-compose-up.md %}
 

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -74,8 +74,12 @@ services:
 {% include templates/install/docker/docker-create-folders-sudo-explained.md %}
 
 ```
-mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
 mkdir -p ~/.mytb-edge-logs && sudo chown -R 799:799 ~/.mytb-edge-logs
+```
+{: .copy-code}
+
+```
+mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
 ```
 {: .copy-code}
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -79,6 +79,14 @@ services:
 
 {% include templates/install/docker/docker-create-folders-sudo-explained.md %}
 
+```
+mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
+mkdir -p ~/.mytb-edge-logs && sudo chown -R 799:799 ~/.mytb-edge-logs
+```
+{: .copy-code}
+
+**NOTE**: Replace directory `~/.mytb-edge-data` and `~/.mytb-edge-logs` with directories you’re planning to use in `docker-compose.yml`.
+
 {% assign serviceName = "tbedge" %}
 {% include templates/install/docker/docker-compose-up.md %}
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -80,10 +80,15 @@ services:
 {% include templates/install/docker/docker-create-folders-sudo-explained.md %}
 
 ```
-mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
 mkdir -p ~/.mytb-edge-logs && sudo chown -R 799:799 ~/.mytb-edge-logs
 ```
 {: .copy-code}
+
+```
+mkdir -p ~/.mytb-edge-data && sudo chown -R 799:799 ~/.mytb-edge-data
+```
+{: .copy-code}
+
 
 **NOTE**: Replace directory `~/.mytb-edge-data` and `~/.mytb-edge-logs` with directories you’re planning to use in `docker-compose.yml`.
 


### PR DESCRIPTION
## PR Checklist

Before:
![15-52-00](https://user-images.githubusercontent.com/3466101/228242029-06855cc1-1f1c-42c5-9ec7-8c61cf950734.png)

After:
![15-53-09](https://user-images.githubusercontent.com/3466101/228242307-a674d99f-af33-4666-8576-d4dca77e9154.png)


- [x] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

