### PR TITLE
Feature/X509 device provisioning: cloud

### DIFF
--- a/_includes/templates/ssl/certificates-chain.md
+++ b/_includes/templates/ssl/certificates-chain.md
@@ -200,7 +200,7 @@ Execute the following command to upload temperature readings to ThingsBoard Clou
 
 {% if docsPrefix == 'paas/' %}
 ```bash
-mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
+mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "mqtt.thingsboard.cloud" -p "8883" \
 -t "v1/devices/me/telemetry" --key deviceKey.pem --cert chain.pem -m {"temperature":25}
 ```
 {: .copy-code}
@@ -210,7 +210,6 @@ mosquitto_pub --cafile tb-server-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
 -t "v1/devices/me/telemetry" --key deviceKey.pem --cert chain.pem -m {"temperature":25}
 ```
 {: .copy-code}
-{% endif %}
 
 Similar command for the [self-signed](/docs/{{docsPrefix}}user-guide/mqtt-over-ssl/#self-signed-certificates-generation) server certificate:
 
@@ -219,6 +218,8 @@ mosquitto_pub --insecure --cafile server.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883"
 -t "v1/devices/me/telemetry" --key deviceKey.pem --cert chain.pem -m {"temperature":25}
 ```
 {: .copy-code}
+{% endif %}
+
  
 
 Don't forget to replace **YOUR_TB_HOST** with the host of your ThingsBoard instance.

--- a/_includes/templates/ssl/certificates-chain.md
+++ b/_includes/templates/ssl/certificates-chain.md
@@ -6,8 +6,9 @@ ThingsBoard Team has already provisioned a valid certificate for [ThingsBoard Cl
 Follow the [MQTT over SSL](/docs/{{docsPrefix}}user-guide/mqtt-over-ssl/) guide to provision server certificate if you are hosting your own ThingsBoard instance.
 
 Once provisioned, you should prepare a certificate chain in pem format. This chain will be used by mqtt client to validate the server certificate.
-Save the chain to your working directory as "**tb-server-chain.pem**".
-An example of certificate chain for *mqtt.thingsboard.cloud* is located [here](/docs/paas/user-guide/resources/mqtt-over-ssl/tb-server-chain.pem).
+Save the chain to your working directory as {% if docsPrefix == 'paas/' %}"**tb-cloud-chain.pem**".{% else %}"**tb-server-chain.pem**".{% endif %}
+An example of certificate chain for *mqtt.thingsboard.cloud* is located 
+{% if docsPrefix == 'paas/' %}[here](/docs/paas/user-guide/resources/mqtt-over-ssl/tb-cloud-chain.pem).{% else %}[here](/docs/paas/user-guide/resources/mqtt-over-ssl/tb-server-chain.pem).{% endif %}
 
 #### Step 2. Generate Client certificate chain
 
@@ -197,11 +198,19 @@ Alternatively, the same can be done through the [REST API](/docs/{{docsPrefix}}r
 
 Execute the following command to upload temperature readings to ThingsBoard Cloud using secure channel:
 
+{% if docsPrefix == 'paas/' %}
+```bash
+mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
+-t "v1/devices/me/telemetry" --key deviceKey.pem --cert chain.pem -m {"temperature":25}
+```
+{: .copy-code}
+{% else %}
 ```bash
 mosquitto_pub --cafile tb-server-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
 -t "v1/devices/me/telemetry" --key deviceKey.pem --cert chain.pem -m {"temperature":25}
 ```
 {: .copy-code}
+{% endif %}
 
 Similar command for the [self-signed](/docs/{{docsPrefix}}user-guide/mqtt-over-ssl/#self-signed-certificates-generation) server certificate:
 

--- a/_includes/templates/ssl/certificates-leaf.md
+++ b/_includes/templates/ssl/certificates-leaf.md
@@ -45,7 +45,7 @@ Execute the following command to upload temperature readings to ThingsBoard Clou
 
 {% if docsPrefix == 'paas/' %}
 ```bash
-mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
+mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "mqtt.thingsboard.cloud" -p "8883" \
 -t "v1/devices/me/telemetry" --key key.pem --cert cert.pem -m {"temperature":25}
 ```
 {: .copy-code}

--- a/_includes/templates/ssl/certificates-leaf.md
+++ b/_includes/templates/ssl/certificates-leaf.md
@@ -6,8 +6,9 @@ ThingsBoard Team has already provisioned a valid certificate for [ThingsBoard Cl
 Follow the [MQTT over SSL](/docs/{{docsPrefix}}user-guide/mqtt-over-ssl/) guide to provision server certificate if you are hosting your own ThingsBoard instance.
 
 Once provisioned, you should prepare a certificate chain in pem format. This chain will be used by mqtt client to validate the server certificate.
-Save the chain to your working directory as "**tb-server-chain.pem**".
-An example of certificate chain for *mqtt.thingsboard.cloud* is located [here](/docs/paas/user-guide/resources/mqtt-over-ssl/tb-server-chain.pem).
+Save the chain to your working directory as {% if docsPrefix == 'paas/' %}"**tb-cloud-chain.pem**".{% else %}"**tb-server-chain.pem**".{% endif %}
+An example of certificate chain for *mqtt.thingsboard.cloud* is located
+{% if docsPrefix == 'paas/' %}[here](/docs/paas/user-guide/resources/mqtt-over-ssl/tb-cloud-chain.pem).{% else %}[here](/docs/paas/user-guide/resources/mqtt-over-ssl/tb-server-chain.pem).{% endif %}
 
 #### Step 2. Generate Client certificate
 
@@ -42,10 +43,18 @@ Alternatively, the same can be done through the [REST API](/docs/{{docsPrefix}}r
 
 Execute the following command to upload temperature readings to ThingsBoard Cloud using secure channel:
 
+{% if docsPrefix == 'paas/' %}
+```bash
+mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
+-t "v1/devices/me/telemetry" --key key.pem --cert cert.pem -m {"temperature":25}
+```
+{: .copy-code}
+{% else %}
 ```bash
 mosquitto_pub --cafile tb-server-chain.pem -d -q 1 -h "YOUR_TB_HOST" -p "8883" \
 -t "v1/devices/me/telemetry" --key key.pem --cert cert.pem -m {"temperature":25}
 ```
 {: .copy-code}
+{% endif %}
 
 Don't forget to replace **YOUR_TB_HOST** with the host of your ThingsBoard instance.

--- a/docs/paas/user-guide/certificates.md
+++ b/docs/paas/user-guide/certificates.md
@@ -15,47 +15,17 @@ It is similar to [access token](/docs/{{docsPrefix}}user-guide/access-token/) au
 
 Instructions below will describe how to connect MQTT client using X.509 Certificate to ThingsBoard Cloud.
 
-#### Step 1. Download Server certificate chain
+<br>In particular, there are two strategies that can be used for establishing connection between client and ThingsBoard:
 
-The client device verifies the identity of a server using server certificate. ThingsBoard Cloud uses a valid certificate.
-Please download the certificate chain using this [**link**](/docs/{{docsPrefix}}user-guide/resources/mqtt-over-ssl/tb-cloud-chain.pem)
-and save it to your working directory as "**tb-cloud-chain.pem**".
+- **X.509 Certificate chain** - *recommended*. <br>
+  Configure ThingsBoard to trust all client certificates from a specific trust anchor (*intermediate certificate*).
+  The device name is automatically discovered from the certificate Common Name using configurable regular expression.
+  This feature eliminates the need for manual certificate updates on each device when certificate rotation occurs.
+  Furthermore, it allows auto-provisioning new devices over MQTT, if *Create new devices* is enabled in the configuration.
+- **X.509 Certificate.** <br> Configure ThingsBoard to accept connections from the specific devices using pre-configured client certificates.
 
-#### Step 2. Generate Client certificate
+{% capture contenttogglespecx509 %}
+X.509 Certificate chain <small>(recommended)</small>%,%x509Chain%,%templates/ssl/certificates-chain.md%br%
+X.509 Certificate%,%X509Leaf%,%templates/ssl/certificates-leaf.md%br%{% endcapture %}
 
-Use the following command to generate the self-signed private key and x509 certificate. 
-The command is based on the **openssl** tool which is most likely already installed on your workstation:
-
-To generate the RSA based key and certificate, use:
-
-```bash
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes
-```
-{: .copy-code}
-
-To generate the EC based key and certificate, use:
-
-```bash
-openssl ecparam -out key.pem -name secp256r1 -genkey
-openssl req -new -key key.pem -x509 -nodes -days 365 -out cert.pem 
-```
-{: .copy-code}
-
-The output of the command will be a private key file *key.pem* and a public certificate *cert.pem*. 
-We will use them in next steps.
-
-#### Step 3. Provision Client Public Key as Device Credentials
-
-Go to **ThingsBoard Web UI -> Device Groups -> Group "All" -> Your Device -> Device Credentials**. 
-Select **X.509 Certificate** device credentials, insert the contents of *cert.pem* file and click save.
-Alternatively, the same can be done through the [REST API](/docs/{{docsPrefix}}reference/rest-api/).
-
-#### Step 4. Test the connection
-
-Execute the following command to upload temperature readings to ThingsBoard Cloud using secure channel:
-
-```bash
-mosquitto_pub --cafile tb-cloud-chain.pem -d -q 1 -h "mqtt.thingsboard.cloud" -p "8883" \
--t "v1/devices/me/telemetry" --key key.pem --cert cert.pem -m {"temperature":25}
-```
-{: .copy-code}
+{% include content-toggle.html content-toggle-id="ubuntuThingsboardX509" toggle-spec=contenttogglespecx509 %}


### PR DESCRIPTION
PAAS: Add documentation for X.509 Certificate chain authentication and auto-provisioning over MQTT.
Replace tb-server-chain.pem usages on cloud into tb-cloud-chain.pem

## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

