### PR TITLE
Widget Development Guide. Fix in Alarm widget to fetch alarms correctly

### DIFF
--- a/_includes/docs/user-guide/contribution/widgets-development.md
+++ b/_includes/docs/user-guide/contribution/widgets-development.md
@@ -688,7 +688,7 @@ The **Widget Editor** will be opened, pre-populated with the content of the defa
  
 ```javascript
 self.onInit = function() {
-    var pageLink = self.ctx.pageLink();
+    var pageLink = self.ctx.pageLink(100);
 
     pageLink.typeList = self.ctx.widgetConfig.alarmTypeList;
     pageLink.statusList = self.ctx.widgetConfig.alarmStatusList;


### PR DESCRIPTION
In [Alarm widget section](https://thingsboard.io/docs/user-guide/contribution/widgets-development/#alarm-widget) Javascript code should be changed from: 
`var pageLink = self.ctx.pageLink();` to `var pageLink = self.ctx.pageLink(100);` in order to fetch alarms data in a proper way.

Affected pages:
- https://thingsboard.io/docs/user-guide/contribution/widgets-development

## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

