### PR TITLE
Add PAGES_REPO_NWO env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,25 @@ git clone https://github.com/thingsboard/thingsboard.github.io.git website
 ### Deploy the site using the docker run command
 
 Please replace the `THINGSBOARD_WEBSITE_DIR` with the full path to your local thingsboard.github.io repository.
+>To deploy a fork, you need to replace the environment variable PAGES_REPO_NWO with the name of your repository.
+As example: \
+`PAGES_REPO_NWO="your_github_nickname/thingsboard.github.io"`
 
 ```bash
-docker run --rm -d -p 4000:4000 --name thingsboard_website --volume="THINGSBOARD_WEBSITE_DIR:/website" thingsboard/website
+docker run --rm -d -p 4000:4000 --name thingsboard_website -e PAGES_REPO_NWO="thingsboard/thingsboard.github.io" --volume="THINGSBOARD_WEBSITE_DIR:/website" thingsboard/website
 ```
+
+
 
 ### Deploy the site using the docker-compose file
 
-Please replace the `THINGSBOARD_WEBSITE_DIR` with the full path to your local thingsboard.github.io repository and create docker-compose.yml file:
+Please replace the `THINGSBOARD_WEBSITE_DIR` with the full path to your local thingsboard.github.io repository.
+
+>To deploy a fork, you need to replace the environment variable PAGES_REPO_NWO with the name of your repository.
+As example:\
+`PAGES_REPO_NWO: "your_github_nickname/thingsboard.github.io"`
+
+Create docker-compose.yml file:
 
 ```bash
 cat <<EOT | sudo tee docker-compose.yml
@@ -88,6 +99,8 @@ services:
     container_name: thingsboard_website
     restart: always
     image: "thingsboard/website"
+    environment:
+      PAGES_REPO_NWO: "thingsboard/thingsboard.github.io"
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
When the repository is deployed in a docker without a previous run in the OS environment, the startup fails:
![image](https://github.com/thingsboard/thingsboard.github.io/assets/44898346/c14f6b34-15ee-4b70-84d6-84d9c7c8cb69)

Solution: add a `PAGES_REPO_NWO` variable that specifies the name of the repository. By default: `thingsboard/thingsboard.github.io`

## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

