### PR TITLE
Feature/ubuntu installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Any edits you make will be viewable on a lightweight webserver that runs on your
 
 Install Ruby **3.0.x**. If you're on Ubuntu, run this commands:
 
-    sudo apt-get install ruby-full build-essential zlib1g-dev
+    sudo apt-get install ruby-full build-essential zlib1g-dev git
     sudo gem install github-pages jekyll bundler
 
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Clone our site:
 Make any changes you want. Then, to see your changes locally:  
 
 	cd thingsboard.github.io
-	bundle install
+	sudo bundle install
 	bundle exec jekyll serve --host 0.0.0.0
 	
 In case you change the layout or website structure you might need to execute following command:


### PR DESCRIPTION
Debian/Ubuntu "build-essential" might not have "git" package as a dependency so we recommend to install it separately.
---
Without elevated permissions for the "bundle install", it returns errors like

> Retrying download gem from https://rubygems.org/ due to error (2/4): Bundler::PermissionError There was an error while trying to write to `/var/lib/gems/3.1.0/cache/bundler-2.1.4.gem`. It is likely that you need to grant write permissions for that path.

Tested on Debian 12