### PR TITLE
Fix for not shown image

### DIFF
--- a/_includes/docs/devices-library/blocks/basic/thingsboard-upload-example-dashboard.md
+++ b/_includes/docs/devices-library/blocks/basic/thingsboard-upload-example-dashboard.md
@@ -18,7 +18,7 @@
         title: Navigate to the "**Dashboards**" page. By default, you navigate to the dashboard group "All". Click on the "**+**" icon in the top right corner. Select "**Import dashboard**".
     ===
         image: /images/user-guide/dashboards/dashboard-import-pe.png,
-        title:In the dashboard import window, upload the JSON file and click "**Import**" button.
+        title: In the dashboard import window, upload the JSON file and click "**Import**" button.
     ===
         image: /images/user-guide/dashboards/dashboard-import-1-pe.png,
         title: Dashboard has been imported.


### PR DESCRIPTION
## PR Checklist
Was:
![image](https://github.com/thingsboard/thingsboard.github.io/assets/48650591/7d5e0e93-2987-4b7a-aeca-e4a24c83983b)
Fixed:


- [ ] No broken links found using link-checker.
<img width="782" alt="Screenshot 2023-10-11 at 12 48 37" src="https://github.com/thingsboard/thingsboard.github.io/assets/48650591/0b4ea9b4-70c6-4f85-a3e4-14892765f419">


## Linkchecker


Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

