### PR TITLE
Fixed Getting-started link underlining in IoT-Gateway

### DIFF
--- a/_data/gw/docs-home.yml
+++ b/_data/gw/docs-home.yml
@@ -5,8 +5,6 @@ toc:
   path: /docs/iot-gateway/
 - title: What is ThingsBoard IoT Gateway?
   path: /docs/iot-gateway/what-is-iot-gateway/
-- title: Getting Started
-  path: /docs/iot-gateway/getting-started/
 - title: Configuration guides
   section:
     - title: General configuration


### PR DESCRIPTION
Fixed Getting-started link underlining in IoT-Gateway when this route is active

## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
```

