### PR TITLE
Feature/linkchecker docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ docker exec thingsboard_website bash -c "./generate-previews.sh images/solution-
 Use the following command to check the broken links.
 
 ```bash
-docker run -it --rm --network=host ghcr.io/linkchecker/linkchecker --check-extern http://0.0.0.0:4000/
+docker run --rm --network=host ghcr.io/linkchecker/linkchecker http://0.0.0.0:4000/ --check-extern --no-warnings
 ```
 
-## Update pages in _includes/docs/pe/user-guide/install directory in accordance with thingsboard/thingsborad-pe repositories: 
+## Update pages in _includes/docs/pe/user-guide/install directory in accordance with thingsboard/thingsboard-pe repositories: 
 
 Use the following command from the project root directory to regenerate configuration pages (first script parameter is TB version: 'ce' or 'pe', second parameter is relative path to TB repository):
     

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,6 +7,6 @@
 Use the following command to check the broken links. 
 
 ```bash
-docker run --rm -it ghcr.io/linkchecker/linkchecker --check-extern http://172.16.1.16:4000
+docker run --rm --network=host ghcr.io/linkchecker/linkchecker http://0.0.0.0:4000/ --check-extern --no-warnings
 ```
 


### PR DESCRIPTION
## PR Checklist

- [ ] No broken links found using link-checker.

## Linkchecker

Use the following command to check the broken links. 

```bash
docker run --rm --network=host ghcr.io/linkchecker/linkchecker http://0.0.0.0:4000/ --check-extern --no-warnings
```

