### PR TITLE
Update Flutter ThingsBoard Mobile compatibility matrix to latest version 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,7 +90,7 @@ release:
   pe_edge_ver: 3.6.1pe # use X.X.Xpe to be in sync with demo/cloud
   pe_edge_full_ver: 3.6.1EDGEPE
   # <<< EDGE
-  ce_flutter_app_ver: 1.0.6
-  pe_flutter_app_ver: 1.0.7
+  ce_flutter_app_ver: 1.0.7
+  pe_flutter_app_ver: 1.0.8
   broker_full_ver: 1.2.0
   broker_branch: release-1.2.0

--- a/_includes/docs/mobile/getting-started.md
+++ b/_includes/docs/mobile/getting-started.md
@@ -52,6 +52,11 @@ Determine the Flutter {{appPrefix}} Mobile Application version according to the 
     </thead>
     <tbody>
         <tr>
+            <td>3.6.0+</td>
+            <td>1.0.7</td>
+            <td>1.0.7</td>
+        </tr>
+        <tr>
             <td>3.5.0+</td>
             <td>1.0.6</td>
             <td>1.0.6</td>
@@ -78,6 +83,11 @@ Determine the Flutter {{appPrefix}} Mobile Application version according to the 
         </tr>
     </thead>
     <tbody>
+        <tr>
+            <td>3.6.0PE+</td>
+            <td>1.0.8</td>
+            <td>1.0.8</td>
+        </tr>
         <tr>
             <td>3.5.0PE+</td>
             <td>1.0.7</td>

--- a/_includes/docs/pe/reference/dart-client.md
+++ b/_includes/docs/pe/reference/dart-client.md
@@ -33,7 +33,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```yaml
 dependencies:
-  thingsboard_pe_client: ^1.0.7
+  thingsboard_pe_client: ^1.0.8
 ```
 {: .copy-code}
 

--- a/docs/reference/dart-client.md
+++ b/docs/reference/dart-client.md
@@ -39,7 +39,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```yaml
 dependencies:
-  thingsboard_client: ^1.0.6
+  thingsboard_client: ^1.0.7
 ```
 {: .copy-code}
 


### PR DESCRIPTION
## PR description

The documentation updated the current version of the Dart client and Flutter ThingsBoard Mobile compatibility matrix

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
