### PR TITLE
Fix command to specify ".upgradeversion" for docker

### DIFF
--- a/docs/user-guide/install/pe/docker.md
+++ b/docs/user-guide/install/pe/docker.md
@@ -126,7 +126,7 @@ If you still rely on Docker Compose as docker-compose (with a hyphen) execute ne
 * Change upgradeversion variable to your **current** ThingsBoard version.
 
  ```bash
-sudo sh -c "echo '3.1.0' > ~/.mytbpe-data/.upgradeversion"
+echo '3.1.0' | sudo tee ~/.mytbpe-data/.upgradeversion
 ```
 {: .copy-code}
 


### PR DESCRIPTION
## PR description

When using "sudo sh -c", tilde (~) expands into "/root" instead of the user home directory.
Simple test : ```sudo sh -c "echo ~"```

To get the user home directory with "sh", the tilde must be replaced with the $HOME variable. Alternatively, use a simpler command with "tee".

Affected documentation section: https://thingsboard.io/docs/user-guide/install/pe/docker/#upgrade-starting-from-310pe 

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
