### PR TITLE
Fix broken links on CE & PE Configuration pages

### DIFF
--- a/_includes/docs/user-guide/install/how-to-change-config.md
+++ b/_includes/docs/user-guide/install/how-to-change-config.md
@@ -4,7 +4,7 @@
 This guide will help you to get familiar with ThingsBoard configuration files and parameters. We **recommend** to
 configure ThingsBoard using environment variables. This way you do not need to merge the configuration files when new
 platform release arrives. List of available configuration parameters and corresponding environment variables is
-located [here](#configuration-parameters).
+located {% if docsPrefix == null %}[here](/docs/user-guide/install/config/){% endif %}{% if docsPrefix == "pe/" %}[here](/docs/user-guide/install/pe/config/){% endif %}.
 
 ## How to change configuration parameters?
 

--- a/docs/user-guide/install/pe/config.md
+++ b/docs/user-guide/install/pe/config.md
@@ -4,6 +4,7 @@ assignees:
 - vparomskiy
 title: Core/rule engine deployment parameters
 description: ThingsBoard configuration parameters and environment variables
+redirect_from: "/docs/pe/user-guide/install/config/"
 
 ---
 


### PR DESCRIPTION
## PR description

1. The documentation updated for:
- https://thingsboard.io/docs/user-guide/install/how-to-change-config/
- https://thingsboard.io/docs/user-guide/install/pe/how-to-change-config/

Non-existing links with anchors #configuration-parameters were replaced with links to the appropriate CE and PE pages with config parameters.

2. Added redirect  
from  
https://thingsboard.io/docs/pe/user-guide/install/config/  
to  
https://thingsboard.io/docs/user-guide/install/pe/config/

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
