### PR TITLE
Expose "CoAP Integration" option for CentOS/RHEL Server

### DIFF
--- a/_includes/docs/pe/user-guide/integrations/remote-integrations.md
+++ b/_includes/docs/pe/user-guide/integrations/remote-integrations.md
@@ -150,7 +150,8 @@ MQTT Integrations<br><small>(MQTT, AWS IoT, IBM Watson, The Things Network)</sma
 AWS SQS<br> Integration<br>%,%aws%,%templates/install/integration/aws-rhel.md%br%
 Azure Event Hub<br>Integration<br>%,%azure%,%templates/install/integration/azure-rhel.md%br%
 OPC UA<br> Integration<br>%,%opcua%,%templates/install/integration/opcua-rhel.md%br%
-TCP/UDP<br> Integration<br>%,%tcpudp%,%templates/install/integration/tcpudp-rhel.md{% endcapture %}
+TCP/UDP<br> Integration<br>%,%tcpudp%,%templates/install/integration/tcpudp-rhel.md%br%
+CoAP<br> Integration<br>%,%coap%,%templates/install/integration/coap-rhel.md{% endcapture %}
 
 {% include content-toggle.html content-toggle-id="remoteintegrationinstallrhel" toggle-spec=rhelinstallspec %} 
 


### PR DESCRIPTION
## PR description

"_includes/templates/install/integration/coap-rhel.md" file have been present since https://github.com/thingsboard/thingsboard.github.io/pull/713 but it was unused due to the missing "include".

Affected pages:
- https://thingsboard.io/docs/user-guide/integrations/remote-integrations/#centosrhel-server
- https://thingsboard.io/docs/paas/user-guide/integrations/remote-integrations/#centosrhel-server
   
   
   
![coap_integration_for_rhel_server](https://github.com/thingsboard/thingsboard.github.io/assets/44649402/fad55cef-b341-47fc-a8f8-3152998e805b)


  
  
## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
