### PR TITLE
Fixed Kafka installation command in Ubuntu instructions

### DIFF
--- a/_includes/templates/install/ubuntu-queue-kafka.md
+++ b/_includes/templates/install/ubuntu-queue-kafka.md
@@ -52,7 +52,7 @@ wget https://downloads.apache.org/kafka/3.6.1/kafka_2.13-3.6.1.tgz
 
 tar xzf kafka_2.13-3.6.1.tgz
 
-sudo mv kafka_2.13-3.6.1.tgz /usr/local/kafka
+sudo mv kafka_2.13-3.6.1 /usr/local/kafka
 ```
 {: .copy-code}
 


### PR DESCRIPTION
## PR description

Fixed an incorrect move command from https://github.com/thingsboard/thingsboard.github.io/pull/1298

Affected pages:
- https://thingsboard.io/docs/user-guide/install/ubuntu/
- https://thingsboard.io/docs/user-guide/install/pe/ubuntu/

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
