### PR TITLE
Edge MQTT/CoAP API uses CE/PE doc prefix

### DIFF
--- a/docs/edge/reference/coap-api.md
+++ b/docs/edge/reference/coap-api.md
@@ -4,5 +4,4 @@ title: CoAP Device API Reference
 redirect_from: "/docs/edge/reference/coap-api"
 ---
 
-{% assign docsPrefix = "edge/" %}
 {% include docs/reference/coap-api.md %}

--- a/docs/edge/reference/mqtt-api.md
+++ b/docs/edge/reference/mqtt-api.md
@@ -5,5 +5,4 @@ description: Supported MQTT API Reference for IoT Devices
 redirect_from: "/docs/edge/reference/mqtt-api"
 ---
 
-{% assign docsPrefix = "edge/" %}
 {% include docs/reference/mqtt-api.md %}

--- a/docs/pe/edge/reference/coap-api.md
+++ b/docs/pe/edge/reference/coap-api.md
@@ -4,5 +4,5 @@ title: CoAP Device API Reference
 redirect_from: "/docs/pe/edge/reference/coap-api"
 ---
 
-{% assign docsPrefix = "edge/" %}
+{% assign docsPrefix = "pe/" %}
 {% include docs/reference/coap-api.md %}

--- a/docs/pe/edge/reference/mqtt-api.md
+++ b/docs/pe/edge/reference/mqtt-api.md
@@ -5,5 +5,5 @@ description: Supported MQTT API Reference for IoT Devices
 redirect_from: "/docs/pe/edge/reference/mqtt-api"
 ---
 
-{% assign docsPrefix = "edge/" %}
+{% assign docsPrefix = "pe/" %}
 {% include docs/reference/mqtt-api.md %}


### PR DESCRIPTION
## PR description

The documentation updated for ...

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
