### PR TITLE
Added steps to configure edge ssl using build-in platform mechanism

### DIFF
--- a/_includes/docs/edge/user-guide/grpc-over-ssl.md
+++ b/_includes/docs/edge/user-guide/grpc-over-ssl.md
@@ -1,22 +1,27 @@
-This guide provides instructions on how to secure connections between ThingsBoard and Edge instances using gRPC connections over TLS/SSL. 
+* TOC
+{:toc}
 
-It is divided into two parts: configuring the server side (the platform) and the client side (the edge).
+This guide outlines steps to secure connections between ThingsBoard and Edge instances using gRPC connections over TLS/SSL.
 
-#### TLS configuration of the platform
+You can configure SSL termination in two ways: by utilizing the built-in SSL capabilities of the platform for gRPC traffic or by employing an external load balancer as the termination point.
 
-The guide suggests using HAProxy as the TLS termination point for the platform.
+The instructions are divided into two main parts: configuring the server side (platform) and the client side (edge).
+
+### Server SSL Configuration
+
+Choose between the built-in mechanism or using a load balancer for SSL termination for gRPC traffic. Use the content toggle below to select and view the instructions for each option.
 
 {% capture contenttogglespec %}
-Ubuntu Server%,%ubuntu%,%templates/edge/user-guide/grpc-over-ssl-ubuntu.md%br%
-CentOS/RHEL Server%,%rhel%,%templates/edge/user-guide/grpc-over-ssl-rhel.md{% endcapture %}
+Build-in mechanism%,%build_in%,%templates/edge/user-guide/grpc-over-ssl-build-in.md%br%
+Load Balancer%,%load_balancer%,%templates/edge/user-guide/grpc-over-ssl-load-balancer.md{% endcapture %}
 
 {% include content-toggle.html content-toggle-id="platformOption" toggle-spec=contenttogglespec %}
 
-#### Configuring Edge to Use TLS Connection
+### Configuring Edge to Use SSL Connection
 
-##### Ubuntu or CentOS/RHEL
+#### Ubuntu or CentOS/RHEL
 
-To enable TLS communication on the Edge, execute the following command on Ubuntu or CentOS/RHEL installations:
+To enable SSL communication on the Edge for Ubuntu or CentOS/RHEL installations, execute the following command:
 
 ```bash
 sudo sh -c 'cat <<EOL >> /etc/tb-edge/conf/tb-edge.conf
@@ -25,19 +30,28 @@ EOL'
 ```
 {: .copy-code}
 
+If you are using self-signed certificates, it is necessary to add the server-side public certificate to the Edge's configuration to verify the server's certificate:
 
-To apply the changes, the Edge must be restarted:
+```bash
+sudo sh -c 'cat <<EOL >> /etc/tb-edge/conf/tb-edge.conf
+export CLOUD_RPC_SSL_CERT=certFile.crt
+EOL'
+```
+{: .copy-code}
+
+To apply these changes, restart the Edge:
 
 ```bash
 sudo systemctl restart tb-edge
 ```
 {: .copy-code}
 
-##### Docker
+#### Docker
 
-For Docker setups, ensure that the **CLOUD_RPC_SSL_ENABLED** variable in the **docker-compose.yml** file is set to 'true'.
+In Docker setups, make sure the **CLOUD_RPC_SSL_ENABLED** variable in the `docker-compose.yml` file is set to 'true'. 
+If using self-signed certificates, also set **CLOUD_RPC_SSL_CERT** accordingly.
 
-After this change, the ThingsBoard Edge docker container needs to be restarted using the command:
+After making these changes, restart the ThingsBoard Edge docker container with the command:
 
 ```bash
 docker compose restart mytbedge

--- a/_includes/templates/edge/user-guide/grpc-over-ssl-build-in.md
+++ b/_includes/templates/edge/user-guide/grpc-over-ssl-build-in.md
@@ -1,0 +1,59 @@
+Follow the instructions below to generate your own certificate files. This approach is useful for testing but is time-consuming and not recommended for production environments.
+
+#### Generate a Private Key
+
+Generate a new private key using the command below. This will create a 2048-bit RSA private key and store it in a file named `privateKey.pem`:
+
+```bash
+openssl genpkey -algorithm RSA -out privateKey.pem -pkeyopt rsa_keygen_bits:2048
+```
+{: .copy-code}
+
+#### Generate a Certificate Signing Request (CSR)
+
+Next, use your private key to generate a CSR. 
+You will need to provide details such as your organization's name, common name (domain name), and an email address, which will be included in the certificate's subject field. 
+Save the CSR as `certRequest.csr`:
+
+```bash
+openssl req -new -key privateKey.pem -out certRequest.csr
+```
+{: .copy-code}
+
+{% capture common_name_localhost %}
+If your ThingsBoard server is running locally, ensure you set 'localhost' as the common name (domain name) when generating your certificate. 
+If the server is hosted, use its domain name. 
+
+SSL connections will fail if the certificate's domain name does not match the server's hostname.
+{% endcapture %}
+{% include templates/warn-banner.md content=common_name_localhost %}
+
+
+#### Generate a Self-Signed Certificate
+
+Finally, create a self-signed certificate from your CSR. The following command generates a certificate named `certFile.crt`, valid for 365 days. You can modify the `-days` parameter to adjust the certificate's validity period:
+
+```bash
+openssl x509 -req -in certRequest.csr -signkey privateKey.pem -out certFile.crt -days 365
+```
+{: .copy-code}
+
+#### Enable SSL Communication on the Server
+
+For both Ubuntu and CentOS/RHEL installations, enable SSL communication server-side with the following command:
+
+```bash
+sudo sh -c 'cat <<EOL >> /etc/thingsboard/conf/thingsboard.conf
+export EDGES_RPC_SSL_ENABLED=true
+export EDGES_RPC_SSL_CERT=certFile.crt
+export EDGES_RPC_SSL_PRIVATE_KEY=privateKey.pem
+EOL'
+```
+{: .copy-code}
+
+Restart the server to apply the changes:
+
+```bash
+sudo systemctl restart thingsboard
+```
+{: .copy-code}

--- a/_includes/templates/edge/user-guide/grpc-over-ssl-load-balancer.md
+++ b/_includes/templates/edge/user-guide/grpc-over-ssl-load-balancer.md
@@ -1,0 +1,5 @@
+The guide recommends using HAProxy as the SSL termination point for your platform.
+
+For those utilizing Ubuntu Server, please follow [these specific steps](/docs/user-guide/install/pe/add-haproxy-ubuntu/#step-6-configure-edge-tls-communication-optional){: target="_blank"}.
+
+If you're on a CentOS/RHEL Server, adhere to [these instructions](/docs/user-guide/install/pe/add-haproxy-rhel/#step-6-configure-edge-tls-communication-optional){: target="_blank"}.

--- a/_includes/templates/edge/user-guide/grpc-over-ssl-rhel.md
+++ b/_includes/templates/edge/user-guide/grpc-over-ssl-rhel.md
@@ -1,1 +1,0 @@
-Ensure that you have configured Edge TLS communication in HAProxy for the CentOS/RHEL Server by following these [Post-installation steps](/docs/user-guide/install/pe/add-haproxy-rhel/#step-6-configure-edge-tls-communication-optional){: target="_blank"}.

--- a/_includes/templates/edge/user-guide/grpc-over-ssl-ubuntu.md
+++ b/_includes/templates/edge/user-guide/grpc-over-ssl-ubuntu.md
@@ -1,1 +1,0 @@
-Ensure that you have configured Edge TLS communication in HAProxy for the Ubuntu Server by following these [Post-installation steps](/docs/user-guide/install/pe/add-haproxy-ubuntu/#step-6-configure-edge-tls-communication-optional){: target="_blank"}.


### PR DESCRIPTION
## PR description

The documentation updated for ...

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
