### PR TITLE
update and refactor monolith installation guides

### DIFF
--- a/_includes/templates/install/create-tb-db-rhel.md
+++ b/_includes/templates/install/create-tb-db-rhel.md
@@ -1,41 +1,9 @@
 Then, press "Ctrl+D" to return to main user console.
 
-After configuring the password, edit the pg_hba.conf to use MD5 authentication with the postgres user.
-
-Edit pg_hba.conf file: 
-
-```bash
-sudo nano /var/lib/pgsql/15/data/pg_hba.conf
-
-```
-{: .copy-code}
-
-Locate the following lines:
-
-```text
-# IPv4 local connections:
-host    all             all             127.0.0.1/32            ident
-```
-
-Replace `ident` with `md5`:
-
-```text
-host    all             all             127.0.0.1/32            md5
-```
-
-Finally, you should restart the PostgreSQL service to initialize the new configuration:
-
-```bash
-sudo systemctl restart postgresql-15.service
-
-```
-{: .copy-code}
-
-Connect to the database to create thingsboard DB:
+After configuring the password, connect to the database to create thingsboard DB:
 
 ```bash
 psql -U postgres -d postgres -h 127.0.0.1 -W
-
 ```
 {: .copy-code}
 
@@ -44,6 +12,5 @@ Execute create database statement
 ```bash
 CREATE DATABASE thingsboard;
 \q
-
 ```
 {: .copy-code}

--- a/_includes/templates/install/memory-on-slow-machines.md
+++ b/_includes/templates/install/memory-on-slow-machines.md
@@ -8,7 +8,7 @@ sudo nano /etc/thingsboard/conf/thingsboard.conf
 Add the following lines to the configuration file. 
 
 ```bash
-# Update ThingsBoard memory usage and restrict it to 256MB in /etc/thingsboard/conf/thingsboard.conf
-export JAVA_OPTS="$JAVA_OPTS -Xms256M -Xmx256M"
+# Update ThingsBoard memory usage and restrict it to 2G in /etc/thingsboard/conf/thingsboard.conf
+export JAVA_OPTS="$JAVA_OPTS -Xms2G -Xmx2G"
 ```
 {: .copy-code}

--- a/_includes/templates/install/postgres-install-rhel.md
+++ b/_includes/templates/install/postgres-install-rhel.md
@@ -6,29 +6,27 @@ sudo yum update
 ```
 {: .copy-code}
 
-**For CentOS/RHEL 7:**
+Install the repository.
 
-```bash
-# Install the repository RPM:
-sudo yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-# Install packages
-sudo yum -y install epel-release yum-utils
-sudo yum-config-manager --enable pgdg15
-sudo yum install postgresql15-server postgresql15
-# Initialize your PostgreSQL DB
-sudo /usr/pgsql-15/bin/postgresql-15-setup initdb
-sudo systemctl start postgresql-15
-# Optional: Configure PostgreSQL to start on boot
-sudo systemctl enable --now postgresql-15
-
-```
-{: .copy-code}
-
-**For RHEL 8 and derivatives (Alma, Rocky, Oracle):**
+**For CentOS/RHEL 8:**
 
 ```bash
 # Install the repository RPM:
 sudo yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+```
+{: .copy-code}
+
+**For CentOS/RHEL 9:**
+
+```bash
+# Install the repository RPM:
+sudo yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+```
+{: .copy-code}
+
+Install the package.
+
+```bash
 # Install packages
 sudo dnf -qy module disable postgresql
 sudo dnf -y install postgresql15 postgresql15-server
@@ -37,7 +35,6 @@ sudo /usr/pgsql-15/bin/postgresql-15-setup initdb
 sudo systemctl start postgresql-15
 # Optional: Configure PostgreSQL to start on boot
 sudo systemctl enable --now postgresql-15
-
 ```
 {: .copy-code}
 

--- a/_includes/templates/install/windows-memory-on-slow-machines.md
+++ b/_includes/templates/install/windows-memory-on-slow-machines.md
@@ -21,4 +21,6 @@ and change them to
 <startargument>-Xms256m</startargument>
 <startargument>-Xmx256m</startargument>
 ```
+
+change "256m" to approximately 1/3rd of your total RAM (in MB)
 {: .copy-code}

--- a/docs/user-guide/install/pe/rhel.md
+++ b/docs/user-guide/install/pe/rhel.md
@@ -14,23 +14,12 @@ description: Installing ThingsBoard PE on CentOS/RHEL
 
 ### Prerequisites
 
-This guide describes how to install ThingsBoard on RHEL/CentOS 7/8. 
+This guide describes how to install ThingsBoard on RHEL 8/9, CentOS 8/9, or their derivatives (Alma, Rocky, Oracle, etc). 
 Hardware requirements depend on chosen database and amount of devices connected to the system. 
-To run ThingsBoard and PostgreSQL on a single machine you will need at least 1Gb of RAM.
+To run ThingsBoard and PostgreSQL on a single machine you will need at least 4Gb of RAM.
 To run ThingsBoard and Cassandra on a single machine you will need at least 8Gb of RAM.
 
 Before continue to installation execute the following commands in order to install necessary tools:
-
-**For CentOS 7:**
-
-```bash
-# Install wget
-sudo yum install -y nano wget
-# Add latest EPEL release for CentOS 7
-sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-```
-{: .copy-code}
 
 **For CentOS 8:**
 
@@ -39,7 +28,16 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 sudo yum install -y nano wget
 # Add latest EPEL release for CentOS 8
 sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+{: .copy-code}
 
+**For CentOS 9:**
+
+```bash
+# Install wget
+sudo yum install -y nano wget
+# Add latest EPEL release for CentOS 9
+sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 ```
 {: .copy-code}
 
@@ -120,7 +118,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 6. [Optional] Memory update for slow machines (1GB of RAM) 
+### Step 6. [Optional] Memory update for slow machines (4GB of RAM) 
 
 {% include templates/install/memory-on-slow-machines.md %} 
 
@@ -142,7 +140,7 @@ sudo firewall-cmd --reload
 {% include templates/start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 90 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 ### Step 9. Install ThingsBoard WebReport component

--- a/docs/user-guide/install/pe/ubuntu.md
+++ b/docs/user-guide/install/pe/ubuntu.md
@@ -14,9 +14,9 @@ description: Installing ThingsBoard on Ubuntu
 
 ### Prerequisites
 
-This guide describes how to install ThingsBoard on Ubuntu 18.04 LTS / Ubuntu 20.04 LTS.
+This guide describes how to install ThingsBoard on Ubuntu 20.04 LTS / 22.04 LTS.
 Hardware requirements depend on chosen database and amount of devices connected to the system. 
-To run ThingsBoard and PostgreSQL on a single machine you will need at least 1Gb of RAM.
+To run ThingsBoard and PostgreSQL on a single machine you will need at least 4Gb of RAM.
 To run ThingsBoard and Cassandra on a single machine you will need at least 8Gb of RAM.
 
 ### Step 1. Install Java 11 (OpenJDK) 
@@ -96,7 +96,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 6. [Optional] Memory update for slow machines (1GB of RAM) 
+### Step 6. [Optional] Memory update for slow machines (4GB of RAM) 
 
 {% include templates/install/memory-on-slow-machines.md %} 
 
@@ -109,7 +109,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 {% include templates/start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 90 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 ### Step 9. Install ThingsBoard WebReport component

--- a/docs/user-guide/install/pe/windows.md
+++ b/docs/user-guide/install/pe/windows.md
@@ -17,9 +17,9 @@ description: Installing ThingsBoard on Windows
 ### Prerequisites
 
 This guide describes how to install ThingsBoard on a Windows machine.
-Instructions below are provided for Windows 10/8.1/8/7 32-bit/64-bit. 
+Instructions below are provided for Windows 11/10. 
 Hardware requirements depend on chosen database and amount of devices connected to the system. 
-To run ThingsBoard and PostgreSQL on a single machine you will need at least 2Gb of RAM.
+To run ThingsBoard and PostgreSQL on a single machine you will need at least 4Gb of RAM.
 To run ThingsBoard and Cassandra on a single machine you will need at least 8Gb of RAM.
 
 ### Step 1. Install Java 11 (OpenJDK) 
@@ -93,7 +93,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="windowsThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 6. [Optional] Memory update for slow machines (1GB of RAM) 
+### Step 6. [Optional] Memory update for slow machines 
 
 {% include templates/install/windows-memory-on-slow-machines.md %} 
 
@@ -121,7 +121,7 @@ ThingsBoard installed successfully!
 {% include templates/windows-start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 90 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 ### Step 9. Install ThingsBoard Web Report Server component

--- a/docs/user-guide/install/rhel.md
+++ b/docs/user-guide/install/rhel.md
@@ -12,23 +12,12 @@ description: Installing ThingsBoard CE on CentOS/RHEL
 
 ### Prerequisites
 
-This guide describes how to install ThingsBoard on RHEL/CentOS 7/8. 
+This guide describes how to install ThingsBoard on RHEL 8/9, CentOS 8/9, or their derivatives (Alma, Rocky, Oracle, etc). 
 Hardware requirements depend on chosen database and amount of devices connected to the system. 
-To run ThingsBoard and PostgreSQL on a single machine you will need at least 1Gb of RAM.
+To run ThingsBoard and PostgreSQL on a single machine you will need at least 4Gb of RAM.
 To run ThingsBoard and Cassandra on a single machine you will need at least 8Gb of RAM.
 
 Before continue to installation execute the following commands in order to install necessary tools:
-
-**For CentOS 7:**
-
-```bash
-# Install wget
-sudo yum install -y nano wget
-# Add latest EPEL release for CentOS 7
-sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-
-```
-{: .copy-code}
 
 **For CentOS 8:**
 
@@ -37,7 +26,16 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 sudo yum install -y nano wget
 # Add latest EPEL release for CentOS 8
 sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+```
+{: .copy-code}
 
+**For CentOS 9:**
+
+```bash
+# Install wget
+sudo yum install -y nano wget
+# Add latest EPEL release for CentOS 9
+sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 ```
 {: .copy-code}
 
@@ -88,7 +86,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 5. [Optional] Memory update for slow machines (1GB of RAM) 
+### Step 5. [Optional] Memory update for slow machines (4GB of RAM) 
 
 {% include templates/install/memory-on-slow-machines.md %} 
 
@@ -111,7 +109,7 @@ sudo firewall-cmd --reload
 {% include templates/start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 90 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 ### Post-installation steps

--- a/docs/user-guide/install/rpi.md
+++ b/docs/user-guide/install/rpi.md
@@ -66,7 +66,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 5. Memory update for slow machines (1GB of RAM) 
+### Step 5. Memory update for slow machines (4GB of RAM) 
 
 {% include templates/install/memory-on-slow-machines.md %} 
 
@@ -79,7 +79,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 {% include templates/start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 240 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 ### Troubleshooting

--- a/docs/user-guide/install/ubuntu.md
+++ b/docs/user-guide/install/ubuntu.md
@@ -12,9 +12,9 @@ description: Installing ThingsBoard CE on Ubuntu Server
 
 ### Prerequisites
 
-This guide describes how to install ThingsBoard on Ubuntu 18.04 LTS / Ubuntu 20.04 LTS.
+This guide describes how to install ThingsBoard on Ubuntu 20.04 LTS / 22.04 LTS.
 Hardware requirements depend on chosen database and amount of devices connected to the system. 
-To run ThingsBoard and PostgreSQL on a single machine you will need at least 1Gb of RAM.
+To run ThingsBoard and PostgreSQL on a single machine you will need at least 4Gb of RAM.
 To run ThingsBoard and Cassandra on a single machine you will need at least 8Gb of RAM.
 
 ### Step 1. Install Java 11 (OpenJDK) 
@@ -64,7 +64,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 5. [Optional] Memory update for slow machines (1GB of RAM) 
+### Step 5. [Optional] Memory update for slow machines (4GB of RAM) 
 
 {% include templates/install/memory-on-slow-machines.md %} 
 
@@ -77,7 +77,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 {% include templates/start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 90 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 ### Post-installation steps

--- a/docs/user-guide/install/windows.md
+++ b/docs/user-guide/install/windows.md
@@ -17,9 +17,9 @@ description: Installing ThingsBoard on Windows
 ### Prerequisites
 
 This guide describes how to install ThingsBoard on a Windows machine.
-Instructions below are provided for Windows 10/8.1/8/7 32-bit/64-bit. 
+Instructions below are provided for Windows 11/10. 
 Hardware requirements depend on chosen database and amount of devices connected to the system. 
-To run ThingsBoard and PostgreSQL on a single machine you will need at least 2Gb of RAM.
+To run ThingsBoard and PostgreSQL on a single machine you will need at least 4Gb of RAM.
 To run ThingsBoard and Cassandra on a single machine you will need at least 8Gb of RAM.
 
 ### Step 1. Install Java 11 (OpenJDK) 
@@ -62,7 +62,7 @@ Confluent Cloud <small>(Event Streaming Platform based on Kafka)</small>%,%confl
 
 {% include content-toggle.liquid content-toggle-id="windowsThingsboardQueue" toggle-spec=contenttogglespecqueue %} 
 
-### Step 5. [Optional] Memory update for slow machines (1GB of RAM) 
+### Step 5. [Optional] Memory update for slow machines (4GB of RAM) 
 
 {% include templates/install/windows-memory-on-slow-machines.md %} 
 
@@ -90,7 +90,7 @@ ThingsBoard installed successfully!
 {% include templates/windows-start-service.md %}
 
 {% capture 90-sec-ui %}
-Please allow up to 90 seconds for the Web UI to start. This is applicable only for slow machines with 1-2 CPUs or 1-2 GB RAM.{% endcapture %}
+Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 {% include templates/info-banner.md content=90-sec-ui %}
 
 


### PR DESCRIPTION
## PR description

Updated Ubuntu. RHEL, Raspberry and Windows, CE and PE.
- RHEL - updated versions from 7/8 to 8/9; refactored changes according to the changes in new OS and packages
-- tested on RHEL 8/9, CentOS Stream 8/9, Oracle 9, Alma 9, Rocky 9, Fedora 38/39
- Ubuntu - updated versions from 18/20 to 20/22
- Windows - updated versions from 10/8/7 to 11/10, removed mention of 32-bit arch
- All monoliths installs - changed min recommended RAM from 1GB to 4GB; updated Xms Xmx JAVAOPTS optional step accordingly (2G); change "please wait up to 90 secs for UI to startup" to not mention slow machines

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
