### PR TITLE
Fixed dashboard's guide link in Guides page

### DIFF
--- a/_data/paas/guides-data.yml
+++ b/_data/paas/guides-data.yml
@@ -3,19 +3,19 @@
   subtitle: These guides provide quick overview of main ThingsBoard features. Designed to be completed in 15-30 minutes.
   id: GettingStartedGuides
   section:
-    - path: /docs/getting-started-guides/helloworld/
+    - path: /docs/paas/getting-started-guides/helloworld/
       title: Hello world
       subtitle: Learn how to collect IoT device data using MQTT, HTTP or CoAP and visualize it on a simple dashboard. Provides variety of sample scripts that you can run on your PC or laptop to simulate the device.
       keywords: mqtt http coap visualization helloworld
       video: false
       pe: false
-    - path: /docs/user-guide/dashboards/
+    - path: /docs/paas/user-guide/dashboards/
       title: Working with IoT dashboards
       subtitle: Learn how to perform basic operations over Dashboards.
       keywords: dashboards
       video: false
       pe: false
-    - path: /docs/user-guide/rule-engine-2-0/re-getting-started/
+    - path: /docs/paas/user-guide/rule-engine-2-0/re-getting-started/
       title: Getting started with Rule Engine
       subtitle: Learn about ThingsBoard rule engine and typical use cases you can implement. Review Hello World example and learn how-to enable filtering of incoming telemetry messages.
       keywords: device management attributes

--- a/_data/pe/guides-data.yml
+++ b/_data/pe/guides-data.yml
@@ -3,19 +3,19 @@
   subtitle: These guides provide quick overview of main ThingsBoard features. Designed to be completed in 15-30 minutes.
   id: GettingStartedGuides
   section:
-    - path: /docs/getting-started-guides/helloworld/
+    - path: /docs/getting-started-guides/helloworld-pe/
       title: Hello world
       subtitle: Learn how to collect IoT device data using MQTT, HTTP or CoAP and visualize it on a simple dashboard. Provides variety of sample scripts that you can run on your PC or laptop to simulate the device.
       keywords: mqtt http coap visualization helloworld
       video: false
       pe: false
-    - path: /docs/user-guide/dashboards/
+    - path: /docs/pe/user-guide/dashboards/
       title: Working with IoT dashboards
       subtitle: Learn how to perform basic operations over Dashboards.
       keywords: dashboards
       video: false
       pe: false
-    - path: /docs/user-guide/rule-engine-2-0/re-getting-started/
+    - path: /docs/pe/user-guide/rule-engine-2-0/re-getting-started/
       title: Getting started with Rule Engine
       subtitle: Learn about ThingsBoard rule engine and typical use cases you can implement. Review Hello World example and learn how-to enable filtering of incoming telemetry messages.
       keywords: device management attributes

--- a/_includes/docs/guides.md
+++ b/_includes/docs/guides.md
@@ -110,8 +110,6 @@
     
 </script>
 
-{% assign guides = site.data.guides-data %}
-
 <ul id="markdown-toc">
     {% for item in guides %}
     {% if guidesVersion == 'paas' and item.paaspage == 'false' %}

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -4,5 +4,5 @@ title: Guides
 notitle: "true"
 ---
 
-{% assign guidesVersion = "ce" %}
+{% assign guides = site.data.guides-data %}
 {% include docs/guides.md %}

--- a/docs/paas/guides.md
+++ b/docs/paas/guides.md
@@ -4,5 +4,5 @@ title: Guides
 notitle: "true"
 ---
 
-{% assign guidesVersion = "paas" %}
+{% assign guides = site.data.paas.guides-data %}
 {% include docs/guides.md %}

--- a/docs/pe/guides.md
+++ b/docs/pe/guides.md
@@ -4,4 +4,5 @@ title: Guides
 notitle: "true"
 ---
 
+{% assign guides = site.data.pe.guides-data %}
 {% include docs/guides.md %}


### PR DESCRIPTION
## PR description

- Fixed the dashboard's guide link in the Guides page;
- Fixed switching between CE, PE, and PAAS versions of the site.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
