### PR TITLE
Add a note about LwM2M object versions.

### DIFF
--- a/_includes/docs/reference/lwm2m-api.md
+++ b/_includes/docs/reference/lwm2m-api.md
@@ -37,6 +37,7 @@ This part of documentation covers provisioning of your first LwM2M device in Thi
 {% unless docsPrefix == 'paas/' %}
 System administrator is able to upload LwM2M models using "Resource library" UI located in the "System settings" menu.
 One may upload multiple files at once. We recommend you to download list of available models from official [github](https://github.com/OpenMobileAlliance/lwm2m-registry) repo and import all of them.
+Note that LwM2M models are versioned, and make sure to upload those that match the LwM2M object versions provided by your devices.
 
 {% include images-gallery.html imageCollection="upload-models" showListImageTitles="true" %}
 


### PR DESCRIPTION
Add a note about LwM2M object versions. It would have helped avoid corresponding pitfalls.  Others seem to have had those problems as well.

See https://github.com/thingsboard/thingsboard/issues/6179

## PR description

The documentation updated for LwM2M Device API Reference includes a note making people aware that LwM2M object versions must be considered, when uploading LwM2M models.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
