### PR TITLE
Remove duplicete filter WiFi for device library

### DIFF
--- a/docs/devices-library/ace-iot-gateway-and-siemens-logo.md
+++ b/docs/devices-library/ace-iot-gateway-and-siemens-logo.md
@@ -2,7 +2,7 @@
 layout: devices-library-article
 title: How to connect ACE MQTT 4G GPS Gateway to ThingsBoard?
 category: Other devices
-connectivity: HTTP, MQTT, Ethernet, WiFi
+connectivity: HTTP, MQTT, Ethernet, WIFI
 vendor: ACE Automation
 deviceImageFileName: ace-iot-gateway.png
 ---

--- a/docs/devices-library/teltonika-rut955-and-siemens-logo.md
+++ b/docs/devices-library/teltonika-rut955-and-siemens-logo.md
@@ -2,7 +2,7 @@
 layout: devices-library-article
 title: How to connect Teltonika RUT955 to ThingsBoard?
 category: Other devices
-connectivity: HTTP, MQTT, Ethernet, WiFi
+connectivity: HTTP, MQTT, Ethernet, WIFI
 vendor: Teltonika
 deviceImageFileName: teltonika-rut955.jpeg
 ---

--- a/docs/paas/devices-library/ace-iot-gateway-and-siemens-logo.md
+++ b/docs/paas/devices-library/ace-iot-gateway-and-siemens-logo.md
@@ -2,7 +2,7 @@
 layout: devices-library-article
 title: How to connect ACE MQTT 4G GPS Gateway to ThingsBoard?
 category: Other devices
-connectivity: HTTP, MQTT, Ethernet, WiFi
+connectivity: HTTP, MQTT, Ethernet, WIFI
 vendor: ACE Automation
 deviceImageFileName: ace-iot-gateway.png
 docsPrefix: paas/

--- a/docs/paas/devices-library/teltonika-rut955-and-siemens-logo.md
+++ b/docs/paas/devices-library/teltonika-rut955-and-siemens-logo.md
@@ -2,7 +2,7 @@
 layout: devices-library-article
 title: How to connect Teltonika RUT955 to ThingsBoard?
 category: Other devices
-connectivity: HTTP, MQTT, Ethernet, WiFi
+connectivity: HTTP, MQTT, Ethernet, WIFI
 vendor: Teltonika
 deviceImageFileName: teltonika-rut955.jpeg
 docsPrefix: paas

--- a/docs/pe/devices-library/ace-iot-gateway-and-siemens-logo.md
+++ b/docs/pe/devices-library/ace-iot-gateway-and-siemens-logo.md
@@ -2,7 +2,7 @@
 layout: devices-library-article
 title: How to connect ACE MQTT 4G GPS Gateway to ThingsBoard?
 category: Other devices
-connectivity: HTTP, MQTT, Ethernet, WiFi
+connectivity: HTTP, MQTT, Ethernet, WIFI
 vendor: ACE Automation
 deviceImageFileName: ace-iot-gateway.png
 docsPrefix: pe/

--- a/docs/pe/devices-library/teltonika-rut-955-and-siemens-logo.md
+++ b/docs/pe/devices-library/teltonika-rut-955-and-siemens-logo.md
@@ -2,7 +2,7 @@
 layout: devices-library-article
 title: How to connect Teltonika RUT955 to ThingsBoard?
 category: Other devices
-connectivity: HTTP, MQTT, Ethernet, WiFi
+connectivity: HTTP, MQTT, Ethernet, WIFI
 vendor: Teltonika
 deviceImageFileName: teltonika-rut955.jpeg
 docsPrefix: pe/


### PR DESCRIPTION
## PR description

Before fix:
![image](https://github.com/thingsboard/thingsboard.github.io/assets/83352633/077e25cb-fda1-414c-93b1-e2e704135a0a)

After fix:
![image](https://github.com/thingsboard/thingsboard.github.io/assets/83352633/86d3ed2f-56b6-43a7-b6b5-962beee2d39c)

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
