### PR TITLE
upgrade instructions for 3.7

### DIFF
--- a/_includes/templates/install/tb-370-update-linux.md
+++ b/_includes/templates/install/tb-370-update-linux.md
@@ -1,0 +1,13 @@
+{% capture tb_3_7_0_upgrade_note %}
+**Important note before upgrading to ThingsBoard 3.7**
+
+ThingsBoard backend was migrated to Java 17. Install JDK 17 and ensure that system's default Java version is set to 17.
+
+Please refer to Step 1 of the corresponding installation guide for detailed instructions:
+
+[**Ubuntu**](/docs/user-guide/install/ubuntu/#step-1-install-java-17-openjdk)
+
+[**CentOS/RHEL**](/docs/user-guide/install/rhel/#step-1-install-java-17-openjdk)
+
+{% endcapture %}
+{% include templates/warn-banner.md content=tb_3_7_0_upgrade_note %}

--- a/_includes/templates/install/tb-370-update-windows.md
+++ b/_includes/templates/install/tb-370-update-windows.md
@@ -1,0 +1,9 @@
+{% capture tb_3_7_0_upgrade_note %}
+**Important note before upgrading to ThingsBoard 3.7**
+
+ThingsBoard backend was migrated to Java 17. Install JDK 17 and ensure that system's default Java version is set to 17.
+
+Please refer to [**Step 1 of the installation guide**](/docs/user-guide/install/windows/#step-1-install-java-17-openjdk) for detailed instructions.
+
+{% endcapture %}
+{% include templates/warn-banner.md content=tb_3_7_0_upgrade_note %}

--- a/docs/user-guide/install/pe/resources/3.7pe/thingsboard-centos-download.sh
+++ b/docs/user-guide/install/pe/resources/3.7pe/thingsboard-centos-download.sh
@@ -1,0 +1,1 @@
+wget https://dist.thingsboard.io/thingsboard-3.7pe.rpm

--- a/docs/user-guide/install/pe/resources/3.7pe/thingsboard-centos-installation.sh
+++ b/docs/user-guide/install/pe/resources/3.7pe/thingsboard-centos-installation.sh
@@ -1,0 +1,1 @@
+sudo rpm -Uvh thingsboard-3.7pe.rpm

--- a/docs/user-guide/install/pe/resources/3.7pe/thingsboard-ubuntu-download.sh
+++ b/docs/user-guide/install/pe/resources/3.7pe/thingsboard-ubuntu-download.sh
@@ -1,0 +1,1 @@
+wget https://dist.thingsboard.io/thingsboard-3.7pe.deb

--- a/docs/user-guide/install/pe/resources/3.7pe/thingsboard-ubuntu-installation.sh
+++ b/docs/user-guide/install/pe/resources/3.7pe/thingsboard-ubuntu-installation.sh
@@ -1,0 +1,1 @@
+sudo dpkg -i thingsboard-3.7pe.deb

--- a/docs/user-guide/install/pe/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/upgrade-instructions.md
@@ -13,6 +13,17 @@ description: ThingsBoard PE IoT platform upgrade instructions
         <a href="#prepare-for-upgrading-thingsboard-centos-ubuntu" id="markdown-toc-prepare-for-upgrading-thingsboard-centos-ubuntu">Prepare for upgrading ThingsBoard (CentOS, Ubuntu)</a>
   </li>
   <li>
+      <a href="#upgrading-to-37pe" id="markdown-toc-upgrading-to-37pe">Upgrading to 3.7PE</a>
+      <ul>
+          <li>
+              <a href="#ubuntucentos-37" id="markdown-toc-ubuntucentos-37">Ubuntu/CentOS</a>
+          </li>
+          <li>
+              <a href="#windows-37" id="markdown-toc-windows-37">Windows</a>
+          </li>
+      </ul>
+  </li>
+  <li>
       <a href="#upgrading-to-364pe" id="markdown-toc-upgrading-to-364pe">Upgrading to 3.6.4PE</a>
       <ul>
           <li>
@@ -199,6 +210,115 @@ sudo systemctl start cassandra
 **PostgreSQL**
 Do nothing, postgresql is already running.
 
+
+## Upgrading to 3.7PE
+
+### Ubuntu/CentOS {#ubuntucentos-37}
+
+{% capture difference %}
+**NOTE:**
+<br>
+These upgrade steps are applicable for ThingsBoard version 3.6.4PE. In order to upgrade to 3.7PE you need to [**upgrade to 3.6.4PE first**](/docs/user-guide/install/pe/upgrade-instructions/#ubuntucentos-364).
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+{% include templates/install/tb-370-update-linux.md %}
+
+#### ThingsBoard PE package download
+
+{% capture tabspec %}thingsboard-download-3-7
+thingsboard-download-3-7-ubuntu,Ubuntu,shell,resources/3.7pe/thingsboard-ubuntu-download.sh,/docs/user-guide/install/resources/3.7pe/thingsboard-ubuntu-download.sh
+thingsboard-download-3-6-4-centos,CentOS,shell,resources/3.7pe/thingsboard-centos-download.sh,/docs/user-guide/install/resources/3.7pe/thingsboard-centos-download.sh{% endcapture %}
+{% include tabs.html %}
+
+#### ThingsBoard PE service upgrade
+
+* Stop ThingsBoard service if it is running.
+
+```bash
+sudo service thingsboard stop
+```
+{: .copy-code}
+
+* Install Thingsboard Web Report component as described [here](/docs/user-guide/install/pe/ubuntu/#step-9-install-thingsboard-webreport-component).
+
+{% capture tabspec %}thingsboard-installation-3-7
+thingsboard-installation-3-7-ubuntu,Ubuntu,shell,resources/3.7pe/thingsboard-ubuntu-installation.sh,/docs/user-guide/install/resources/3.7pe/thingsboard-ubuntu-installation.sh
+thingsboard-installation-3-7-centos,CentOS,shell,resources/3.7pe/thingsboard-centos-installation.sh,/docs/user-guide/install/resources/3.7pe/thingsboard-centos-installation.sh{% endcapture %}
+{% include tabs.html %}
+
+{% capture difference %}
+**NOTE:**
+<br>
+Package installer may ask you to merge your thingsboard configuration. It is preferred to use **merge option** to make sure that all your previous parameters will not be overwritten.
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+Execute regular upgrade script:
+
+```bash
+sudo /usr/share/thingsboard/bin/install/upgrade.sh --fromVersion=3.6.4
+```
+{: .copy-code}
+
+#### Start the service
+
+```bash
+sudo service thingsboard start
+```
+{: .copy-code}
+
+### Windows {#windows-37}
+
+{% capture difference %}
+**NOTE:**
+<br>
+These upgrade steps are applicable for ThingsBoard version 3.6.4PE. In order to upgrade to 3.7PE you need to [**upgrade to 3.6.4PE first**](/docs/user-guide/install/pe/upgrade-instructions/#windows-364).
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+{% include templates/install/tb-370-update-windows.md %}
+
+#### ThingsBoard PE package download
+
+Download ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-3.7pe.exe](https://dist.thingsboard.io/thingsboard-windows-setup-3.7pe.exe).
+
+#### ThingsBoard PE service upgrade
+
+* Stop ThingsBoard service if it is running.
+
+```text
+net stop thingsboard
+```
+{: .copy-code}
+
+* Make a backup of previous ThingsBoard PE configuration located in \<ThingsBoard install dir\>\conf (for ex. C:\thingsboard\conf).
+* Run installation package **thingsboard-windows-setup-3.7pe.exe**.
+* Compare and merge your old ThingsBoard configuration files (from the backup you made in the first step) with new ones.
+* Finally, run **upgrade.bat** script to upgrade ThingsBoard to the new version.
+
+{% capture difference %}
+**NOTE:**
+<br>
+Scripts listed above should be executed using Administrator Role.
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+Execute regular upgrade script:
+
+```text
+C:\thingsboard>upgrade.bat --fromVersion=3.6.4
+```
+{: .copy-code}
+
+#### Start the service
+
+```text
+net start thingsboard
+```
+{: .copy-code}
+
+
 ## Upgrading to 3.6.4PE
 
 ### Ubuntu/CentOS {#ubuntucentos-364}
@@ -277,7 +397,7 @@ net stop thingsboard
 {: .copy-code}
 
 * Make a backup of previous ThingsBoard PE configuration located in \<ThingsBoard install dir\>\conf (for ex. C:\thingsboard\conf).
-* Run installation package **thingsboard-windows-setup-3.6.3pe.exe**.
+* Run installation package **thingsboard-windows-setup-3.6.4pe.exe**.
 * Compare and merge your old ThingsBoard configuration files (from the backup you made in the first step) with new ones.
 * Finally, run **upgrade.bat** script to upgrade ThingsBoard to the new version.
 

--- a/docs/user-guide/install/resources/3.7/thingsboard-centos-download.sh
+++ b/docs/user-guide/install/resources/3.7/thingsboard-centos-download.sh
@@ -1,0 +1,1 @@
+wget https://github.com/thingsboard/thingsboard/releases/download/v3.7/thingsboard-3.7.rpm

--- a/docs/user-guide/install/resources/3.7/thingsboard-centos-installation.sh
+++ b/docs/user-guide/install/resources/3.7/thingsboard-centos-installation.sh
@@ -1,0 +1,1 @@
+sudo rpm -Uvh thingsboard-3.7.rpm

--- a/docs/user-guide/install/resources/3.7/thingsboard-ubuntu-download.sh
+++ b/docs/user-guide/install/resources/3.7/thingsboard-ubuntu-download.sh
@@ -1,0 +1,1 @@
+wget https://github.com/thingsboard/thingsboard/releases/download/v3.7/thingsboard-3.7.deb

--- a/docs/user-guide/install/resources/3.7/thingsboard-ubuntu-installation.sh
+++ b/docs/user-guide/install/resources/3.7/thingsboard-ubuntu-installation.sh
@@ -1,0 +1,1 @@
+sudo dpkg -i thingsboard-3.7.deb

--- a/docs/user-guide/install/upgrade-instructions.md
+++ b/docs/user-guide/install/upgrade-instructions.md
@@ -11,6 +11,17 @@ description: ThingsBoard IoT platform upgrade instructions
 
 <ul id="markdown-toc">
     <li>
+      <a href="#upgrading-to-37" id="markdown-toc-upgrading-to-37">Upgrading to 3.7</a>
+      <ul>
+          <li>
+              <a href="#ubuntucentos-37" id="markdown-toc-ubuntucentos-37">Ubuntu/CentOS</a>
+          </li>
+          <li>
+              <a href="#windows-37" id="markdown-toc-windows-37">Windows</a>
+          </li>
+      </ul>
+    </li>
+    <li>
       <a href="#upgrading-to-364" id="markdown-toc-upgrading-to-364">Upgrading to 3.6.4</a>
       <ul>
           <li>
@@ -91,6 +102,113 @@ description: ThingsBoard IoT platform upgrade instructions
     <a href="/docs/user-guide/install/old-upgrade-instructions/" id="markdown-toc-upgrading-to-240">Older versions</a>
     </li> 
 </ul>
+
+
+## Upgrading to 3.7 {#upgrading-to-37}
+
+### Ubuntu/CentOS {#ubuntucentos-37}
+
+{% capture difference %}
+**NOTE:**
+<br>
+These upgrade steps are applicable for ThingsBoard version 3.6.4. In order to upgrade to 3.7 you need to [**upgrade to 3.6.4 first**](/docs/user-guide/install/upgrade-instructions/#ubuntucentos-364).
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+{% include templates/install/tb-370-update-linux.md %}
+
+#### ThingsBoard package download
+
+{% capture tabspec %}thingsboard-download-3-7
+thingsboard-download-3-7-ubuntu,Ubuntu,shell,resources/3.7/thingsboard-ubuntu-download.sh,/docs/user-guide/install/resources/3.7/thingsboard-ubuntu-download.sh
+thingsboard-download-3-7-centos,CentOS,shell,resources/3.7/thingsboard-centos-download.sh,/docs/user-guide/install/resources/3.7/thingsboard-centos-download.sh{% endcapture %}
+{% include tabs.html %}
+
+#### ThingsBoard service upgrade
+
+* Stop ThingsBoard service if it is running.
+
+```bash
+sudo service thingsboard stop
+```
+{: .copy-code}
+
+{% capture tabspec %}thingsboard-installation-3-7
+thingsboard-installation-3-7-ubuntu,Ubuntu,shell,resources/3.7/thingsboard-ubuntu-installation.sh,/docs/user-guide/install/resources/3.7/thingsboard-ubuntu-installation.sh
+thingsboard-installation-3-7-centos,CentOS,shell,resources/3.7/thingsboard-centos-installation.sh,/docs/user-guide/install/resources/3.7/thingsboard-centos-installation.sh{% endcapture %}
+{% include tabs.html %}
+
+{% capture difference %}
+**NOTE:**
+<br>
+Package installer may ask you to merge your thingsboard configuration. It is preferred to use **merge option** to make sure that all your previous parameters will not be overwritten.
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+Execute regular upgrade script:
+
+```bash
+sudo /usr/share/thingsboard/bin/install/upgrade.sh --fromVersion=3.6.4
+```
+{: .copy-code}
+
+#### Start the service
+
+```bash
+sudo service thingsboard start
+```
+{: .copy-code}
+
+### Windows {#windows-37}
+
+{% capture difference %}
+**NOTE:**
+<br>
+These upgrade steps are applicable for ThingsBoard version 3.6.4. In order to upgrade to 3.7 you need to [**upgrade to 3.6.4 first**](/docs/user-guide/install/upgrade-instructions/#windows-364).
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+{% include templates/install/tb-370-update-windows.md %}
+
+#### ThingsBoard package download
+
+Download ThingsBoard installation archive for Windows: [thingsboard-windows-3.7.zip](https://github.com/thingsboard/thingsboard/releases/download/v3.7/thingsboard-windows-3.7.zip).
+
+#### ThingsBoard service upgrade
+
+* Stop ThingsBoard service if it is running.
+
+```text
+net stop thingsboard
+```
+{: .copy-code}
+
+* Make a backup of previous ThingsBoard configuration located in \<ThingsBoard install dir\>\conf (for ex. C:\thingsboard\conf).
+* Remove ThingsBoard install dir.
+* Unzip installation archive to ThingsBoard install dir.
+* Compare and merge your old ThingsBoard configuration files (from the backup you made in the first step) with new ones.
+* Finally, run **upgrade.bat** script to upgrade ThingsBoard to the new version.
+
+{% capture difference %}
+**NOTE:**
+<br>
+Scripts listed above should be executed using Administrator Role.
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
+Execute regular upgrade script:
+
+```text
+C:\thingsboard>upgrade.bat --fromVersion=3.6.4
+```
+{: .copy-code}
+
+#### Start the service
+
+```text
+net start thingsboard
+```
+{: .copy-code}
 
 
 ## Upgrading to 3.6.4 {#upgrading-to-364}


### PR DESCRIPTION
## PR description

added upgrade instructions for 3.7, with the warning note about migration to Java 17
minor typo fix in v3.6.4 upgrade for Windows (package was referred to v3.6.3) as well

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
