### PR TITLE
remove legacy options for CE monolith docker setups

### DIFF
--- a/docs/user-guide/install/docker-windows.md
+++ b/docs/user-guide/install/docker-windows.md
@@ -21,21 +21,11 @@ This guide will help you to install and start ThingsBoard using Docker on Window
 
 ## Running
 
-Depending on the database used there are three type of ThingsBoard single instance docker images:
+In this instruction [thingsboard/tb-postgres](https://hub.docker.com/r/thingsboard/tb-postgres/) image will be used. It contains a single instance of ThingsBoard with PostgreSQL database.
 
-* [thingsboard/tb-postgres](https://hub.docker.com/r/thingsboard/tb-postgres/) - single instance of ThingsBoard with PostgreSQL database.
+Running this image requires a server with at least 4GB of RAM (8GB is recommended) and minimum load (few messages per second).
 
-    Recommended option for small servers with at least 1GB of RAM and minimum load (few messages per second). 2-4GB is recommended.
-* [thingsboard/tb-cassandra](https://hub.docker.com/r/thingsboard/tb-cassandra/) - single instance of ThingsBoard with Cassandra database. 
-
-    The most performant and recommended option but requires at least 6GB of RAM. 8GB is recommended.  
-* [thingsboard/tb](https://hub.docker.com/r/thingsboard/tb/) - single instance of ThingsBoard with embedded HSQLDB database. 
-
-    **Note:** Not recommended for any evaluation or production usage and is used only for development purposes and automatic tests. 
-
-In this instruction `thingsboard/tb-postgres` image will be used. You can choose any other images with different databases (see above).
-
-Windows users should use docker managed volume for ThingsBoard DataBase. 
+Windows users should use docker managed volume for ThingsBoard Database. 
 Create docker volume (for ex. `mytb-data`) before executing docker run command:
 Open "Docker Quickstart Terminal". Execute the following command to create docker volume:
 

--- a/docs/user-guide/install/docker.md
+++ b/docs/user-guide/install/docker.md
@@ -23,19 +23,9 @@ This guide will help you to install and start ThingsBoard using Docker on Linux 
 
 ## Running
 
-Depending on the database used there are three type of ThingsBoard single instance docker images:
+In this instruction [thingsboard/tb-postgres](https://hub.docker.com/r/thingsboard/tb-postgres/) image will be used. It contains a single instance of ThingsBoard with PostgreSQL database.
 
-* [thingsboard/tb-postgres](https://hub.docker.com/r/thingsboard/tb-postgres/) - single instance of ThingsBoard with PostgreSQL database.
-
-    Recommended option for small servers with at least 1GB of RAM and minimum load (few messages per second). 2-4GB is recommended.
-* [thingsboard/tb-cassandra](https://hub.docker.com/r/thingsboard/tb-cassandra/) - single instance of ThingsBoard with Cassandra database. 
-
-    The most performant and recommended option but requires at least 4GB of RAM. 8GB is recommended.  
-* [thingsboard/tb](https://hub.docker.com/r/thingsboard/tb/) - single instance of ThingsBoard with embedded HSQLDB database. 
-
-    **Note:** Not recommended for any evaluation or production usage and is used only for development purposes and automatic tests. 
-
-In this instruction `thingsboard/tb-postgres` image will be used. You can choose any other images with different databases (see above).
+Running this image requires a server with at least 4GB of RAM (8GB is recommended) and minimum load (few messages per second).
 
 ## Choose ThingsBoard queue service
 


### PR DESCRIPTION
## PR description

Old images (`tb` and `tb-cassandra`) for monolith CE Docker installations were removed.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
