### PR TITLE
Remove suggestion of usage Debian Unstable repos on RPi

### DIFF
--- a/docs/user-guide/install/rpi.md
+++ b/docs/user-guide/install/rpi.md
@@ -19,9 +19,6 @@ This guide describes how to install ThingsBoard on a Raspberry Pi running Raspbi
 ### Step 1. Install Java 17 (OpenJDK) 
 
 ```bash
-# Add repository.
-echo "deb http://deb.debian.org/debian unstable main non-free contrib" | sudo tee /etc/apt/sources.list
-
 # Run system update.
 sudo apt update
 


### PR DESCRIPTION
Replacing Debian Stable repositories with Debian Unstable repositories and further system update effectively converts Debian Stable into Debian Unstable ([rolling development version](https://wiki.debian.org/DebianUnstable) , which is generally not recommended for production).

Prior to version 3.7, Thingsboard had dependency on Java 11 which was not available from the Debian Stable/Bookworm official repositories (however, it was temporally kept on repos of "[oldstable](https://packages.debian.org/buster/openjdk-11-jdk)" and "[unstable](https://packages.debian.org/sid/openjdk-11-jdk)" Debian versions).    

Thingsboard v3.7 depends on Java 17 LTS and the required updated package “openjdk-17-jdk” is [available](https://packages.debian.org/bookworm/openjdk-17-jdk) in the Debian Stable repositories, so nowadays there's no need to use extra sources for Java packages.

## PR description

The documentation updated for ...

https://thingsboard.io/docs/user-guide/install/rpi/

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
