### PR TITLE
add cassandra JAVA_HOME note for 3.7.0 upgrade

### DIFF
--- a/docs/user-guide/install/pe/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/upgrade-instructions.md
@@ -274,6 +274,13 @@ sudo /usr/share/thingsboard/bin/install/upgrade.sh --fromVersion=3.6.4
 
 #### Start the service
 
+{% capture cassandra-370 %}
+**In case Cassandra is installed**, ensure that a proper **JAVA_HOME** parameter is set for *cassandra.in.sh* include file. As of 3.7.0 release, latest stable Cassandra version does not support Java 17 yet.
+
+In case action is required, you can refer to *"you will need to install Java..."* section of [**Cassandra installation guide**](/docs/user-guide/install/ubuntu/?ubuntuThingsboardDatabase=hybrid#cassandra-installation). 
+{% endcapture %}
+{% include templates/info-banner.md content=cassandra-370 %}
+
 ```bash
 sudo service thingsboard start
 ```

--- a/docs/user-guide/install/upgrade-instructions.md
+++ b/docs/user-guide/install/upgrade-instructions.md
@@ -154,6 +154,13 @@ sudo /usr/share/thingsboard/bin/install/upgrade.sh --fromVersion=3.6.4
 
 #### Start the service
 
+{% capture cassandra-370 %}
+**In case Cassandra is installed**, ensure that a proper **JAVA_HOME** parameter is set for *cassandra.in.sh* include file. As of 3.7.0 release, latest stable Cassandra version does not support Java 17 yet.
+
+In case action is required, you can refer to *"you will need to install Java..."* section of [**Cassandra installation guide**](/docs/user-guide/install/ubuntu/?ubuntuThingsboardDatabase=hybrid#cassandra-installation). 
+{% endcapture %}
+{% include templates/info-banner.md content=cassandra-370 %}
+
 ```bash
 sudo service thingsboard start
 ```


### PR DESCRIPTION
## PR description

Latest stable Cassandra release does not support Java 17 yet. There are instructions to make Cassandra work with ThingsBoard - they are included in installation guide, but often overlooked when upgrading.

This PR adds note describing the concern, with the link to instructions.
 
## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
