### PR TITLE
Fix for particle integration downlink converter example

### DIFF
--- a/_includes/templates/integration/particle/particle-downlink-js.md
+++ b/_includes/templates/integration/particle/particle-downlink-js.md
@@ -4,7 +4,7 @@ You can use our example of Downlink Converter, or write your own according to yo
 /** Encoder **/
 
 var command = {};
-command["code"] = msg.method;
+command["method"] = msg.method;
 if (msg.params == "false" || msg.params == "true") {
     command["value"] = Boolean.valueOf(msg.params);
 } else {

--- a/_includes/templates/integration/particle/particle-downlink-js.md
+++ b/_includes/templates/integration/particle/particle-downlink-js.md
@@ -6,9 +6,9 @@ You can use our example of Downlink Converter, or write your own according to yo
 var command = {};
 command["method"] = msg.method;
 if (msg.params == "false" || msg.params == "true") {
-    command["value"] = Boolean.valueOf(msg.params);
+    command["params"] = Boolean.valueOf(msg.params);
 } else {
-    command["value"] = msg.params;
+    command["params"] = msg.params;
 }
 
 var result = {

--- a/_includes/templates/integration/particle/particle-downlink-tbel.md
+++ b/_includes/templates/integration/particle/particle-downlink-tbel.md
@@ -4,7 +4,7 @@ You can use our example of Downlink Converter, or write your own according to yo
 /** Encoder **/
 
 var command = {};
-command["code"] = msg.method;
+command["method"] = msg.method;
 if (msg.params == "false" || msg.params == "true") {
     command["value"] = Boolean.valueOf(msg.params);
 } else {

--- a/_includes/templates/integration/particle/particle-downlink-tbel.md
+++ b/_includes/templates/integration/particle/particle-downlink-tbel.md
@@ -6,9 +6,9 @@ You can use our example of Downlink Converter, or write your own according to yo
 var command = {};
 command["method"] = msg.method;
 if (msg.params == "false" || msg.params == "true") {
-    command["value"] = Boolean.valueOf(msg.params);
+    command["params"] = Boolean.valueOf(msg.params);
 } else {
-    command["value"] = msg.params;
+    command["params"] = msg.params;
 }
 
 var result = {


### PR DESCRIPTION
## PR description

Example of doenlink converter for Particle integration contained wrong field name that cause the issue that integration throws error that field is wrong and required field is absent.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
