### PR TITLE
Add dockerized web report

### DIFF
--- a/_includes/templates/install/rhel-webreport-docker.md
+++ b/_includes/templates/install/rhel-webreport-docker.md
@@ -1,0 +1,53 @@
+## Prerequisites
+
+Install Docker [for CentOS](https://docs.docker.com/engine/install/centos/).
+
+{% include templates/install/docker-install-note.md %}
+
+Create docker compose file
+```bash
+cat <<EOT >> tb-web-report.yml
+version: '3.0'
+services:
+  tb-web-report:
+    container_name: tb-web-report
+    restart: always
+    image: "thingsboard/tb-pe-web-report:3.8.0PE"
+    ports:
+      - "8383:8383"
+    env_file:
+      - ./tb-web-report.env
+EOT
+```
+{: .copy-code}
+
+Create .env file for tb-web-report container
+```bash
+cat <<EOT >> tb-web-report.env
+HTTP_BIND_ADDRESS=0.0.0.0
+HTTP_BIND_PORT=8383
+LOGGER_LEVEL=info
+LOG_FOLDER=logs
+LOGGER_FILENAME=tb-web-report-%DATE%.log
+DOCKER_MODE=true
+
+DEFAULT_PAGE_NAVIGATION_TIMEOUT=120000
+DASHBOARD_LOAD_WAIT_TIME=3000
+USE_NEW_PAGE_FOR_REPORT=true
+EOT
+```
+
+Start WebReport service in docker
+```bash
+docker compose -f tb-web-report.yml up -d
+```
+{: .copy-code}
+
+## Troubleshoot container
+
+Read logs from the container
+
+```bash
+docker logs -f tb-web-report
+```
+{: .copycode} 

--- a/_includes/templates/install/rhel-webreport-docker.md
+++ b/_includes/templates/install/rhel-webreport-docker.md
@@ -50,4 +50,4 @@ Read logs from the container
 ```bash
 docker logs -f tb-web-report
 ```
-{: .copycode} 
+{: .copy-code} 

--- a/_includes/templates/install/rhel-webreport-service.md
+++ b/_includes/templates/install/rhel-webreport-service.md
@@ -1,0 +1,46 @@
+
+Download installation package for the [Reports Server](/docs/user-guide/reporting/#reports-server) component:
+
+```bash
+wget https://dist.thingsboard.io/tb-web-report-{{ site.release.pe_ver }}.rpm
+```
+{: .copy-code}
+
+Install third-party libraries:
+
+```bash
+sudo yum install pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 libXext.x86_64 \
+     libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 \
+     alsa-lib.x86_64 atk.x86_64 gtk3.x86_64 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi \
+     xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc unzip nss -y
+```
+{: .copy-code}
+
+Install Roboto fonts:
+
+```bash
+sudo yum install google-roboto-fonts -y
+```
+{: .copy-code}
+
+Install Noto fonts (Japanese, Chinese, etc.):
+
+```bash
+mkdir ~/noto
+cd ~/noto
+wget https://src.fedoraproject.org/repo/extras/chromium/NotoSansCJKjp-hinted.zip/sha512/e7bcbc53a10b8ec3679dcade5a8a94cea7e1f60875ab38f2193b4fa8e33968e1f0abc8184a3df1e5210f6f5c731f96c727c6aa8f519423a29707d2dee5ada193/NotoSansCJKjp-hinted.zip
+unzip NotoSansCJKjp-hinted.zip
+sudo mkdir -p /usr/share/fonts/noto
+sudo cp *.otf /usr/share/fonts/noto
+sudo chmod 655 -R /usr/share/fonts/noto/
+sudo fc-cache -fv
+cd ..
+rm -rf ~/noto
+```
+
+Install and start Web Report service:
+
+```bash
+sudo rpm -Uvh tb-web-report-{{ site.release.pe_ver }}.rpm
+sudo service tb-web-report start
+```

--- a/_includes/templates/install/ubuntu-webreport-docker.md
+++ b/_includes/templates/install/ubuntu-webreport-docker.md
@@ -1,28 +1,29 @@
 ## Prerequisites
 
-{% include templates/install/docker-install.md %}
+Install Docker [for Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 
 {% include templates/install/docker-install-note.md %}
 
 Create docker compose file
 ```bash
-cat <<EOT >> tb-web-report.compose.yml
+cat <<EOT >> tb-web-report.yml
 version: '3.0'
 services:
   tb-web-report:
+    container_name: tb-web-report
     restart: always
     image: "thingsboard/tb-pe-web-report:3.8.0PE"
     ports:
       - "8383:8383"
     env_file:
-      - ./webreport.env
+      - ./tb-web-report.env
 EOT
 ```
 {: .copy-code}
 
 Create .env file for tb-web-report container
 ```bash
-cat <<EOT >> webreport.env
+cat <<EOT >> tb-web-report.env
 HTTP_BIND_ADDRESS=0.0.0.0
 HTTP_BIND_PORT=8383
 LOGGER_LEVEL=info
@@ -38,6 +39,15 @@ EOT
 
 Start WebReport service in docker
 ```bash
-docker compose -f tb-web-report.compose.yml up -d
+docker compose -f tb-web-report.yml up -d
 ```
 {: .copy-code}
+
+## Troubleshoot container
+
+Read logs from the container
+
+```bash
+docker logs -f tb-web-report
+```
+{: .copycode} 

--- a/_includes/templates/install/ubuntu-webreport-docker.md
+++ b/_includes/templates/install/ubuntu-webreport-docker.md
@@ -1,0 +1,44 @@
+## Prerequisites
+
+Install Docker:
+- [for Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
+
+{% include templates/install/docker-install-note.md %}
+
+Create docker compose file
+```bash
+cat <<EOT >> tb-web-report.compose.yml
+version: '3.0'
+services:
+  tb-web-report:
+    restart: always
+    image: "thingsboard/tb-pe-web-report:3.8.0PE"
+    ports:
+      - "8383:8383"
+    env_file:
+      - ./webreport.env
+EOT
+```
+{: .copy-code}
+
+Create .env file for tb-web-report container
+```bash
+cat <<EOT >> webreport.env
+HTTP_BIND_ADDRESS=0.0.0.0
+HTTP_BIND_PORT=8383
+LOGGER_LEVEL=info
+LOG_FOLDER=logs
+LOGGER_FILENAME=tb-web-report-%DATE%.log
+DOCKER_MODE=true
+
+DEFAULT_PAGE_NAVIGATION_TIMEOUT=120000
+DASHBOARD_LOAD_WAIT_TIME=3000
+USE_NEW_PAGE_FOR_REPORT=true
+EOT
+```
+
+Start WebReport service in docker
+```bash
+docker compose -f tb-web-report.compose.yml up -d
+```
+{: .copy-code}

--- a/_includes/templates/install/ubuntu-webreport-docker.md
+++ b/_includes/templates/install/ubuntu-webreport-docker.md
@@ -50,4 +50,4 @@ Read logs from the container
 ```bash
 docker logs -f tb-web-report
 ```
-{: .copycode} 
+{: .copy-code} 

--- a/_includes/templates/install/ubuntu-webreport-service.md
+++ b/_includes/templates/install/ubuntu-webreport-service.md
@@ -1,0 +1,49 @@
+
+Download installation package for the [Reports Server](/docs/user-guide/reporting/#reports-server) component:
+
+```bash
+wget https://dist.thingsboard.io/tb-web-report-{{ site.release.pe_ver }}.deb
+```
+{: .copy-code}
+
+Install third-party libraries:
+
+```bash
+sudo apt install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+     libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+     libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+     ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils unzip wget libgbm-dev
+```
+{: .copy-code}
+
+Install Roboto fonts:
+
+```bash
+sudo apt install fonts-roboto
+```
+{: .copy-code}
+
+Install Noto fonts (Japanese, Chinese, etc.):
+
+```bash
+mkdir ~/noto
+cd ~/noto
+wget https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip
+unzip NotoSansCJKjp-hinted.zip
+sudo mkdir -p /usr/share/fonts/noto
+sudo cp *.otf /usr/share/fonts/noto
+sudo chmod 655 -R /usr/share/fonts/noto/
+sudo fc-cache -fv
+cd ..
+rm -rf ~/noto
+```
+
+
+Install and start Web Report service:
+
+```bash
+sudo dpkg -i tb-web-report-{{ site.release.pe_ver }}.deb
+sudo service tb-web-report start
+```
+{: .copy-code}

--- a/_includes/templates/install/ubuntu-webreport-service.md
+++ b/_includes/templates/install/ubuntu-webreport-service.md
@@ -29,7 +29,7 @@ Install Noto fonts (Japanese, Chinese, etc.):
 ```bash
 mkdir ~/noto
 cd ~/noto
-wget https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip
+wget https://src.fedoraproject.org/repo/extras/chromium/NotoSansCJKjp-hinted.zip/sha512/e7bcbc53a10b8ec3679dcade5a8a94cea7e1f60875ab38f2193b4fa8e33968e1f0abc8184a3df1e5210f6f5c731f96c727c6aa8f519423a29707d2dee5ada193/NotoSansCJKjp-hinted.zip
 unzip NotoSansCJKjp-hinted.zip
 sudo mkdir -p /usr/share/fonts/noto
 sudo cp *.otf /usr/share/fonts/noto

--- a/_includes/templates/install/webreport-docker.md
+++ b/_includes/templates/install/webreport-docker.md
@@ -1,7 +1,6 @@
 ## Prerequisites
 
-Install Docker:
-- [for Ubuntu](https://docs.docker.com/engine/install/ubuntu/)
+{% include templates/install/docker-install.md %}
 
 {% include templates/install/docker-install-note.md %}
 

--- a/docs/user-guide/install/aws-marketplace-pe-upgrade.md
+++ b/docs/user-guide/install/aws-marketplace-pe-upgrade.md
@@ -756,7 +756,7 @@ Execute the following commands:
 ```bash
 mkdir ~/noto
 cd ~/noto
-wget https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip
+wget https://src.fedoraproject.org/repo/extras/chromium/NotoSansCJKjp-hinted.zip/sha512/e7bcbc53a10b8ec3679dcade5a8a94cea7e1f60875ab38f2193b4fa8e33968e1f0abc8184a3df1e5210f6f5c731f96c727c6aa8f519423a29707d2dee5ada193/NotoSansCJKjp-hinted.zip
 unzip NotoSansCJKjp-hinted.zip
 sudo mkdir -p /usr/share/fonts/noto
 sudo cp *.otf /usr/share/fonts/noto

--- a/docs/user-guide/install/pe/rhel.md
+++ b/docs/user-guide/install/pe/rhel.md
@@ -173,7 +173,7 @@ Install Noto fonts (Japanese, Chinese, etc.):
 ```bash
 mkdir ~/noto
 cd ~/noto
-wget https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip
+wget https://src.fedoraproject.org/repo/extras/chromium/NotoSansCJKjp-hinted.zip/sha512/e7bcbc53a10b8ec3679dcade5a8a94cea7e1f60875ab38f2193b4fa8e33968e1f0abc8184a3df1e5210f6f5c731f96c727c6aa8f519423a29707d2dee5ada193/NotoSansCJKjp-hinted.zip
 unzip NotoSansCJKjp-hinted.zip
 sudo mkdir -p /usr/share/fonts/noto
 sudo cp *.otf /usr/share/fonts/noto

--- a/docs/user-guide/install/pe/rhel.md
+++ b/docs/user-guide/install/pe/rhel.md
@@ -145,9 +145,9 @@ Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 ### Step 9. Install ThingsBoard WebReport component
 
 {% capture contenttogglespecreport %}
-WebReport service <small>Run WebReport service on server</small>%,%service%,%templates/install/rhel-webreport-service.md%br%
-WebReport docker <small>Run WebReport service in container</small>%,%dockerized%,%templates/install/webreport-docker.md{% endcapture %}
-{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardWebreport" toggle-spec=contenttogglespecreport %} 
+WebReport docker <small>(Recommended and simple installtion)</small>%,%dockerized%,%templates/install/rhel-webreport-docker.md%br%
+WebReport service <small>(Install service and dependencies manually)</small>%,%service%,%templates/install/rhel-webreport-service.md%br%{% endcapture %}
+{% include content-toggle.liquid content-toggle-id="rhelThingsboardWebreport" toggle-spec=contenttogglespecreport %} 
 
 ### Post-installation steps
 

--- a/docs/user-guide/install/pe/rhel.md
+++ b/docs/user-guide/install/pe/rhel.md
@@ -144,51 +144,10 @@ Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 
 ### Step 9. Install ThingsBoard WebReport component
 
-Download installation package for the [Reports Server](/docs/user-guide/reporting/#reports-server) component:
-
-```bash
-wget https://dist.thingsboard.io/tb-web-report-{{ site.release.pe_ver }}.rpm
-```
-{: .copy-code}
-
-Install third-party libraries:
-
-```bash
-sudo yum install pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 libXext.x86_64 \
-     libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 \
-     alsa-lib.x86_64 atk.x86_64 gtk3.x86_64 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi \
-     xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc unzip nss -y
-```
-{: .copy-code}
-
-Install Roboto fonts:
-
-```bash
-sudo yum install google-roboto-fonts -y
-```
-{: .copy-code}
-
-Install Noto fonts (Japanese, Chinese, etc.):
-
-```bash
-mkdir ~/noto
-cd ~/noto
-wget https://src.fedoraproject.org/repo/extras/chromium/NotoSansCJKjp-hinted.zip/sha512/e7bcbc53a10b8ec3679dcade5a8a94cea7e1f60875ab38f2193b4fa8e33968e1f0abc8184a3df1e5210f6f5c731f96c727c6aa8f519423a29707d2dee5ada193/NotoSansCJKjp-hinted.zip
-unzip NotoSansCJKjp-hinted.zip
-sudo mkdir -p /usr/share/fonts/noto
-sudo cp *.otf /usr/share/fonts/noto
-sudo chmod 655 -R /usr/share/fonts/noto/
-sudo fc-cache -fv
-cd ..
-rm -rf ~/noto
-```
-
-Install and start Web Report service:
-
-```bash
-sudo rpm -Uvh tb-web-report-{{ site.release.pe_ver }}.rpm
-sudo service tb-web-report start
-```
+{% capture contenttogglespecreport %}
+WebReport service <small>Run WebReport service on server</small>%,%service%,%templates/install/rhel-webreport-service.md%br%
+WebReport docker <small>Run WebReport service in container</small>%,%dockerized%,%templates/install/webreport-docker.md{% endcapture %}
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardWebreport" toggle-spec=contenttogglespecreport %} 
 
 ### Post-installation steps
 

--- a/docs/user-guide/install/pe/ubuntu.md
+++ b/docs/user-guide/install/pe/ubuntu.md
@@ -115,7 +115,7 @@ Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 
 {% capture contenttogglespecreport %}
 WebReport service <small>Run WebReport service on server</small>%,%service%,%templates/install/ubuntu-webreport-service.md%br%
-WebReport docker <small>Run WebReport service in container</small>%,%dockerized%,%templates/install/ubuntu-webreport-docker.md{% endcapture %}
+WebReport docker <small>Run WebReport service in container</small>%,%dockerized%,%templates/install/webreport-docker.md{% endcapture %}
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardWebreport" toggle-spec=contenttogglespecreport %} 
 
 ### Post-installation steps

--- a/docs/user-guide/install/pe/ubuntu.md
+++ b/docs/user-guide/install/pe/ubuntu.md
@@ -113,54 +113,10 @@ Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 
 ### Step 9. Install ThingsBoard WebReport component
 
-Download installation package for the [Reports Server](/docs/user-guide/reporting/#reports-server) component:
-
-```bash
-wget https://dist.thingsboard.io/tb-web-report-{{ site.release.pe_ver }}.deb
-```
-{: .copy-code}
-
-Install third-party libraries:
-
-```bash
-sudo apt install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-     libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-     libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-     ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils unzip wget libgbm-dev
-```
-{: .copy-code}
-
-Install Roboto fonts:
-
-```bash
-sudo apt install fonts-roboto
-```
-{: .copy-code}
-
-Install Noto fonts (Japanese, Chinese, etc.):
-
-```bash
-mkdir ~/noto
-cd ~/noto
-wget https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip
-unzip NotoSansCJKjp-hinted.zip
-sudo mkdir -p /usr/share/fonts/noto
-sudo cp *.otf /usr/share/fonts/noto
-sudo chmod 655 -R /usr/share/fonts/noto/
-sudo fc-cache -fv
-cd ..
-rm -rf ~/noto
-```
-
-
-Install and start Web Report service:
-
-```bash
-sudo dpkg -i tb-web-report-{{ site.release.pe_ver }}.deb
-sudo service tb-web-report start
-```
-{: .copy-code}
+{% capture contenttogglespecreport %}
+WebReport service <small>Run WebReport service on server</small>%,%service%,%templates/install/ubuntu-webreport-service.md%br%
+WebReport docker <small>Run WebReport service in container</small>%,%dockerized%,%templates/install/ubuntu-webreport-docker.md{% endcapture %}
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardWebreport" toggle-spec=contenttogglespecreport %} 
 
 ### Post-installation steps
 

--- a/docs/user-guide/install/pe/ubuntu.md
+++ b/docs/user-guide/install/pe/ubuntu.md
@@ -114,8 +114,8 @@ Please allow up to 90 seconds for the Web UI to start.{% endcapture %}
 ### Step 9. Install ThingsBoard WebReport component
 
 {% capture contenttogglespecreport %}
-WebReport service <small>Run WebReport service on server</small>%,%service%,%templates/install/ubuntu-webreport-service.md%br%
-WebReport docker <small>Run WebReport service in container</small>%,%dockerized%,%templates/install/webreport-docker.md{% endcapture %}
+WebReport docker <small>(Recommended and simple installtion)</small>%,%dockerized%,%templates/install/ubuntu-webreport-docker.md%br%
+WebReport service <small>(Install service and dependencies manually)</small>%,%service%,%templates/install/ubuntu-webreport-service.md%br%{% endcapture %}
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardWebreport" toggle-spec=contenttogglespecreport %} 
 
 ### Post-installation steps


### PR DESCRIPTION
## PR description

The documentation for the WebReport component was updated to allow the installation of this service as the docker container. Also, I updated the link for the notosans fonts, as the previous source no longer exists. 

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
