### PR TITLE
Fixed broken Gateway dashboard improvements PRs link in 3.8.0 release  notes

### DIFF
--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -43,7 +43,7 @@ Major release with the following features and bug fixes:
   * [#11063](https://github.com/thingsboard/thingsboard/pull/11063) SCADA layout and symbol library by @ikulikov
   * [#11430](https://github.com/thingsboard/thingsboard/pull/11430) Dashboard layouts and breakpoints by @vvlladd28
   * [#11633](https://github.com/thingsboard/thingsboard/pull/11633) Timewindow redesign by @ChantsovaEkaterina
-  * Gateway dashboard improvements by @maxunbearable in https://github.com/thingsboard/thingsboard/pulls?q=is%3Apr+is%3Amerged+author%3Amaxunbearable+milestone%3A3.8
+  * [multiple PRs](https://github.com/thingsboard/thingsboard/pulls?page=1&q=is%3Apr+is%3Amerged+author%3Amaxunbearable+milestone%3A3.8) Gateway dashboard improvements by @maxunbearable
   * [#11079](https://github.com/thingsboard/thingsboard/pull/11079) Label widgets by @ikulikov
   * [#11138](https://github.com/thingsboard/thingsboard/pull/11138) Notification widget by @ArtemDzhereleiko
 


### PR DESCRIPTION
before:

![Screenshot from 2024-10-16 14-47-51](https://github.com/user-attachments/assets/77e9fddc-4301-4211-8c86-db834aba052e)

after:

![Screenshot from 2024-10-16 14-48-10](https://github.com/user-attachments/assets/5139b855-6945-45c8-b7e2-93ba3cc2e7b7)


## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
