### PR TITLE
Web report fix

### DIFF
--- a/_includes/templates/install/rhel-webreport-docker.md
+++ b/_includes/templates/install/rhel-webreport-docker.md
@@ -12,7 +12,7 @@ services:
   tb-web-report:
     container_name: tb-web-report
     restart: always
-    image: "thingsboard/tb-pe-web-report:3.8.0PE"
+    image: "thingsboard/tb-pe-web-report:{{ site.release.pe_full_ver }}"
     ports:
       - "8383:8383"
     env_file:

--- a/_includes/templates/install/rhel-webreport-docker.md
+++ b/_includes/templates/install/rhel-webreport-docker.md
@@ -36,6 +36,7 @@ DASHBOARD_LOAD_WAIT_TIME=3000
 USE_NEW_PAGE_FOR_REPORT=true
 EOT
 ```
+{: .copy-code}
 
 Start WebReport service in docker
 ```bash

--- a/_includes/templates/install/ubuntu-webreport-docker.md
+++ b/_includes/templates/install/ubuntu-webreport-docker.md
@@ -12,7 +12,7 @@ services:
   tb-web-report:
     container_name: tb-web-report
     restart: always
-    image: "thingsboard/tb-pe-web-report:3.8.0PE"
+    image: "thingsboard/tb-pe-web-report:{{ site.release.pe_full_ver }}"
     ports:
       - "8383:8383"
     env_file:

--- a/_includes/templates/install/ubuntu-webreport-docker.md
+++ b/_includes/templates/install/ubuntu-webreport-docker.md
@@ -36,6 +36,7 @@ DASHBOARD_LOAD_WAIT_TIME=3000
 USE_NEW_PAGE_FOR_REPORT=true
 EOT
 ```
+{: .copy-code}
 
 Start WebReport service in docker
 ```bash

--- a/_includes/templates/install/ubuntu-webreport-service.md
+++ b/_includes/templates/install/ubuntu-webreport-service.md
@@ -9,11 +9,11 @@ wget https://dist.thingsboard.io/tb-web-report-{{ site.release.pe_ver }}.deb
 Install third-party libraries:
 
 ```bash
-sudo apt install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+sudo apt install -yq  libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+     libexpat1 libfontconfig1 libgcc1  libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
      libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
      libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-     ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils unzip wget libgbm-dev
+     ca-certificates fonts-liberation libnss3 lsb-release xdg-utils unzip wget libgbm-dev
 ```
 {: .copy-code}
 

--- a/docs/user-guide/install/aws-marketplace-pe-upgrade.md
+++ b/docs/user-guide/install/aws-marketplace-pe-upgrade.md
@@ -354,11 +354,11 @@ $ cat /var/log/thingsboard/thingsboard.log | grep ERROR
 Execute the following command in order to install Report Server prerequisites:
 
 ```bash
-$ sudo apt install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+sudo apt install -yq  libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+     libexpat1 libfontconfig1 libgcc1  libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
      libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
      libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-     ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget fonts-roboto
+     ca-certificates fonts-liberation libnss3 lsb-release xdg-utils unzip wget libgbm-dev
 ```
 
 Download ThingsBoard Web Report Server installation script:


### PR DESCRIPTION
## PR description

The documentation updated for the ubuntu web report service installation. Deleted libraries (gconf-service libasound2 libgconf-2-4 libappindicator1) that are no longer accessible in ubuntu 24.04 and caused fail of apt install command (no other required packages were installed). Also minor fixes for webreport in docker installation. 

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
