### PR TITLE
Change kafka version to 3.8.1 in install guides

### DIFF
--- a/_includes/templates/install/docker-queue-kafka.md
+++ b/_includes/templates/install/docker-queue-kafka.md
@@ -15,7 +15,7 @@ version: '3.2'
 services:
   kafka:
     restart: always
-    image: bitnami/kafka:3.5.2
+    image: bitnami/kafka:3.8.1
     ports:
       - 9092:9092 #to localhost:9092 from host machine
       - 9093 #for Kraft

--- a/_includes/templates/install/pe-docker-queue-kafka.md
+++ b/_includes/templates/install/pe-docker-queue-kafka.md
@@ -15,7 +15,7 @@ version: '3.2'
 services:
   kafka:
     restart: always
-    image: bitnami/kafka:3.5.2
+    image: bitnami/kafka:3.8.1
     ports:
       - 9092:9092 #to localhost:9092 from host machine
       - 9093 #for Kraft

--- a/_includes/templates/install/queue-kafka-in-docker.md
+++ b/_includes/templates/install/queue-kafka-in-docker.md
@@ -17,7 +17,7 @@ version: '3.2'
 services:
   kafka:
     restart: always
-    image: bitnami/kafka:3.5.2
+    image: bitnami/kafka:3.8.1
     ports:
       - 9092:9092 #to localhost:9092 from host machine
       - 9093 #for Kraft

--- a/_includes/templates/install/ubuntu-queue-kafka.md
+++ b/_includes/templates/install/ubuntu-queue-kafka.md
@@ -48,11 +48,11 @@ sudo systemctl enable --now zookeeper
 ##### Install Kafka
 
 ```text
-wget https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz
+wget https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz
 
-tar xzf kafka_2.13-3.6.2.tgz
+tar -xzf kafka_2.13-3.8.1.tgz
 
-sudo mv kafka_2.13-3.6.2 /usr/local/kafka
+sudo mv kafka_2.13-3.8.1 /usr/local/kafka
 ```
 {: .copy-code}
 

--- a/_includes/templates/install/windows-docker-queue-kafka.md
+++ b/_includes/templates/install/windows-docker-queue-kafka.md
@@ -16,7 +16,7 @@ version: '3.2'
 services:
   kafka:
     restart: always
-    image: bitnami/kafka:3.5.2
+    image: bitnami/kafka:3.8.1
     ports:
       - 9092:9092 #to localhost:9092 from host machine
       - 9093 #for Kraft

--- a/_includes/templates/install/windows-pe-docker-queue-kafka.md
+++ b/_includes/templates/install/windows-pe-docker-queue-kafka.md
@@ -15,7 +15,7 @@ version: '3.2'
 services:
   kafka:
     restart: always
-    image: bitnami/kafka:3.5.2
+    image: bitnami/kafka:3.8.1
     ports:
       - 9092:9092 #to localhost:9092 from host machine
       - 9093 #for Kraft


### PR DESCRIPTION
## PR description

Current [link](https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz) for kafka in documentation returns 404. Changed to a new one, and updated kafka docker image version as well for consistency.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
