### PR TITLE
Article name fix

### DIFF
--- a/_data/edge-pe/docs-home.yml
+++ b/_data/edge-pe/docs-home.yml
@@ -19,7 +19,7 @@ toc:
       path: /docs/pe/edge/user-guide/db-overview/
 - title: Configuration Guides
   section:
-    - title: Device Creation and Cloud Provisioning
+    - title: Device Management
       path: /docs/pe/edge/config/create-device/
 #    - title: Provision Asset from cloud to edge
 #      path: /docs/pe/edge/config/provision-asset/

--- a/_data/edge/docs-home.yml
+++ b/_data/edge/docs-home.yml
@@ -19,7 +19,7 @@ toc:
       path: /docs/edge/user-guide/db-overview/
 - title: Configuration Guides
   section:
-    - title: Device Creation and Cloud Provisioning
+    - title: Device Management
       path: /docs/edge/config/create-device/
 #    - title: Provision Asset from cloud to edge
 #      path: /docs/edge/config/provision-asset/

--- a/docs/edge/config/create-device.md
+++ b/docs/edge/config/create-device.md
@@ -1,7 +1,7 @@
 ---
 layout: docwithnav-edge
-title: Edge Device Creation and Cloud Provisioning
-description: Seamlessly Create Edge Devices and Provision Them to the Cloud
+title: Edge Device Management
+description: Seamlessly create Edge devices and assign them to the Cloud
 
 create-device:
     0:

--- a/docs/pe/edge/config/create-device.md
+++ b/docs/pe/edge/config/create-device.md
@@ -1,7 +1,7 @@
 ---
 layout: docwithnav-pe-edge
-title: Edge Device Creation and Cloud Provisioning
-description: Seamlessly Create Edge Devices and Provision Them to the Cloud
+title: Edge Device Management
+description: Seamlessly create Edge devices and assign them to the Cloud
 
 create-device:
     0:


### PR DESCRIPTION
Article name fix:

-Title fixed from "Device Creation and Cloud Provisioning" to "Device Management"
-article description fixed

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
