### PR TITLE
edge release 3.9.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,11 +84,11 @@ release:
   pe_full_ver: 3.8.1PE
   wd_examples_commit: v3.8.1
   # >>> EDGE
-  edge_ver: 3.8
-  edge_tag: v3.8
-  edge_full_ver: 3.8.0EDGE
-  pe_edge_ver: 3.8pe
-  pe_edge_full_ver: 3.8.0EDGEPE
+  edge_ver: 3.9
+  edge_tag: v3.9
+  edge_full_ver: 3.9.0EDGE
+  pe_edge_ver: 3.9pe
+  pe_edge_full_ver: 3.9.0EDGEPE
   # <<< EDGE
   ce_flutter_app_ver: 1.4.0
   pe_flutter_app_ver: 1.4.0

--- a/_includes/docs/edge/user-guide/install/config.md
+++ b/_includes/docs/edge/user-guide/install/config.md
@@ -179,6 +179,12 @@
 			<td> Per-user rate limit for WS subscriptions</td>
 		</tr>
 		<tr>
+			<td>server.ws.alarms_per_alarm_status_subscription_cache_size</td>
+			<td>TB_ALARMS_PER_ALARM_STATUS_SUBSCRIPTION_CACHE_SIZE</td>
+			<td>10</td>
+			<td> Maximum number of active originator alarm ids being saved in cache for single alarm status subscription. For example, no more than 10 alarm ids on the alarm widget</td>
+		</tr>
+		<tr>
 			<td>server.rest.server_side_rpc.min_timeout</td>
 			<td>MIN_SERVER_SIDE_RPC_TIMEOUT</td>
 			<td>5000</td>
@@ -643,7 +649,7 @@
 		<tr>
 			<td>ui.help.base-url</td>
 			<td>UI_HELP_BASE_URL</td>
-			<td>https://raw.githubusercontent.com/thingsboard/thingsboard-ui-help/release-3.8</td>
+			<td>https://raw.githubusercontent.com/thingsboard/thingsboard-ui-help/release-3.9</td>
 			<td> Base URL for UI help assets</td>
 		</tr>
 	</tbody>
@@ -669,13 +675,328 @@
 			<td>database.ts.type</td>
 			<td>DATABASE_TS_TYPE</td>
 			<td>sql</td>
-			<td> sql or timescale (for hybrid mode, DATABASE_TS_TYPE value should be timescale)</td>
+			<td> cassandra or sql. timescale option is deprecated and will no longer be supported in ThingsBoard 4.0</td>
 		</tr>
 		<tr>
 			<td>database.ts_latest.type</td>
 			<td>DATABASE_TS_LATEST_TYPE</td>
 			<td>sql</td>
-			<td> sql or timescale (for hybrid mode, DATABASE_TS_TYPE value should be timescale)</td>
+			<td> cassandra or sql. timescale option is deprecated and will no longer be supported in ThingsBoard 4.0</td>
+		</tr>
+	</tbody>
+</table>
+
+
+####  Cassandra driver configuration parameters
+
+<table>
+	<thead>
+		<tr>
+			<td style="width: 25%"><b>Parameter</b></td><td style="width: 30%"><b>Environment Variable</b></td><td style="width: 15%"><b>Default Value</b></td><td style="width: 30%"><b>Description</b></td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>cassandra.cluster_name</td>
+			<td>CASSANDRA_CLUSTER_NAME</td>
+			<td>Thingsboard Edge Cluster</td>
+			<td> Thingsboard Edge cluster name</td>
+		</tr>
+		<tr>
+			<td>cassandra.keyspace_name</td>
+			<td>CASSANDRA_KEYSPACE_NAME</td>
+			<td>thingsboard</td>
+			<td> Thingsboard Edge keyspace name</td>
+		</tr>
+		<tr>
+			<td>cassandra.url</td>
+			<td>CASSANDRA_URL</td>
+			<td>127.0.0.1:9042</td>
+			<td> Specify node list</td>
+		</tr>
+		<tr>
+			<td>cassandra.local_datacenter</td>
+			<td>CASSANDRA_LOCAL_DATACENTER</td>
+			<td>datacenter1</td>
+			<td> Specify the local data center name</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.enabled</td>
+			<td>CASSANDRA_USE_SSL</td>
+			<td>false</td>
+			<td> Enable/disable secure connection</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.hostname_validation</td>
+			<td>CASSANDRA_SSL_HOSTNAME_VALIDATION</td>
+			<td>true</td>
+			<td> Enable/disable validation of Cassandra server hostname
+ If enabled, the hostname of the Cassandra server must match the CN of the server certificate</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.trust_store</td>
+			<td>CASSANDRA_SSL_TRUST_STORE</td>
+			<td></td>
+			<td> Set trust store for client authentication of the server (optional, uses trust store from default SSLContext if not set)</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.trust_store_password</td>
+			<td>CASSANDRA_SSL_TRUST_STORE_PASSWORD</td>
+			<td></td>
+			<td> The password for Cassandra trust store key</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.key_store</td>
+			<td>CASSANDRA_SSL_KEY_STORE</td>
+			<td></td>
+			<td> Set key store for server authentication of the client (optional, uses key store from default SSLContext if not set)
+ A key store is only needed if the Cassandra server requires client authentication</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.key_store_password</td>
+			<td>CASSANDRA_SSL_KEY_STORE_PASSWORD</td>
+			<td></td>
+			<td> The password for the Cassandra key store</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.cipher_suites</td>
+			<td>CASSANDRA_SSL_CIPHER_SUITES</td>
+			<td></td>
+			<td> Comma-separated list of cipher suites (optional, uses Java default cipher suites if not set)</td>
+		</tr>
+		<tr>
+			<td>cassandra.jmx</td>
+			<td>CASSANDRA_USE_JMX</td>
+			<td>false</td>
+			<td> Enable/disable JMX</td>
+		</tr>
+		<tr>
+			<td>cassandra.metrics</td>
+			<td>CASSANDRA_USE_METRICS</td>
+			<td>false</td>
+			<td> Enable/disable metrics collection.</td>
+		</tr>
+		<tr>
+			<td>cassandra.compression</td>
+			<td>CASSANDRA_COMPRESSION</td>
+			<td>none</td>
+			<td> NONE SNAPPY LZ4</td>
+		</tr>
+		<tr>
+			<td>cassandra.init_timeout_ms</td>
+			<td>CASSANDRA_CLUSTER_INIT_TIMEOUT_MS</td>
+			<td>300000</td>
+			<td> Specify cassandra cluster initialization timeout in milliseconds (if no hosts are available during startup)</td>
+		</tr>
+		<tr>
+			<td>cassandra.init_retry_interval_ms</td>
+			<td>CASSANDRA_CLUSTER_INIT_RETRY_INTERVAL_MS</td>
+			<td>3000</td>
+			<td> Specify cassandra cluster initialization retry interval (if no hosts available during startup)</td>
+		</tr>
+		<tr>
+			<td>cassandra.max_requests_per_connection_local</td>
+			<td>CASSANDRA_MAX_REQUESTS_PER_CONNECTION_LOCAL</td>
+			<td>32768</td>
+			<td> Cassandra max local requests per connection</td>
+		</tr>
+		<tr>
+			<td>cassandra.max_requests_per_connection_remote</td>
+			<td>CASSANDRA_MAX_REQUESTS_PER_CONNECTION_REMOTE</td>
+			<td>32768</td>
+			<td> Cassandra max remote requests per connection</td>
+		</tr>
+		<tr>
+			<td>cassandra.credentials</td>
+			<td>CASSANDRA_USE_CREDENTIALS</td>
+			<td>false</td>
+			<td> Credential parameters</td>
+		</tr>
+		<tr>
+			<td>cassandra.username</td>
+			<td>CASSANDRA_USERNAME</td>
+			<td></td>
+			<td> Specify your username</td>
+		</tr>
+		<tr>
+			<td>cassandra.password</td>
+			<td>CASSANDRA_PASSWORD</td>
+			<td></td>
+			<td> Specify your password</td>
+		</tr>
+		<tr>
+			<td>cassandra.cloud.secure_connect_bundle_path</td>
+			<td>CASSANDRA_CLOUD_SECURE_BUNDLE_PATH</td>
+			<td></td>
+			<td> /etc/thingsboard/astra/secure-connect-thingsboard.zip</td>
+		</tr>
+		<tr>
+			<td>cassandra.cloud.client_id</td>
+			<td>CASSANDRA_CLOUD_CLIENT_ID</td>
+			<td></td>
+			<td> DucitQPHMzPCBOZqFYexAfKk</td>
+		</tr>
+		<tr>
+			<td>cassandra.cloud.client_secret</td>
+			<td>CASSANDRA_CLOUD_CLIENT_SECRET</td>
+			<td></td>
+			<td> ZnF7FpuHp43FP5BzM+KY8wGmSb4Ql6BhT4Z7sOU13ze+gXQ-n7OkFpNuB,oACUIQObQnK0g4bSPoZhK5ejkcF9F.j6f64j71Sr.tiRe0Fsq2hPS1ZCGSfAaIgg63IydG</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.connect_timeout</td>
+			<td>CASSANDRA_SOCKET_TIMEOUT</td>
+			<td>5000</td>
+			<td> Sets the timeout, in milliseconds, of a native connection from ThingsBoard to Cassandra. The default value is 5000</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.read_timeout</td>
+			<td>CASSANDRA_SOCKET_READ_TIMEOUT</td>
+			<td>20000</td>
+			<td> Timeout before closing the connection. Value set in milliseconds</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.keep_alive</td>
+			<td>CASSANDRA_SOCKET_KEEP_ALIVE</td>
+			<td>true</td>
+			<td> Gets if TCP keep-alive must be used</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.reuse_address</td>
+			<td>CASSANDRA_SOCKET_REUSE_ADDRESS</td>
+			<td>true</td>
+			<td> Enable/Disable reuse-address. The socket option allows for the reuse of local addresses and ports</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.so_linger</td>
+			<td>CASSANDRA_SOCKET_SO_LINGER</td>
+			<td></td>
+			<td> Sets the linger-on-close timeout. By default, this option is not set by the driver. The actual value will be the default from the underlying Netty transport</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.tcp_no_delay</td>
+			<td>CASSANDRA_SOCKET_TCP_NO_DELAY</td>
+			<td>false</td>
+			<td> Enable/Disable Nagle's algorithm</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.receive_buffer_size</td>
+			<td>CASSANDRA_SOCKET_RECEIVE_BUFFER_SIZE</td>
+			<td></td>
+			<td> Sets a hint to the size of the underlying buffers for incoming network I/O. By default, this option is not set by the driver. The actual value will be the default from the underlying Netty transport</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.send_buffer_size</td>
+			<td>CASSANDRA_SOCKET_SEND_BUFFER_SIZE</td>
+			<td></td>
+			<td> Returns the hint to the size of the underlying buffers for outgoing network I/O. By default, this option is not set by the driver. The actual value will be the default from the underlying Netty transport</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.read_consistency_level</td>
+			<td>CASSANDRA_READ_CONSISTENCY_LEVEL</td>
+			<td>ONE</td>
+			<td> Consistency levels in Cassandra can be configured to manage availability versus data accuracy. The consistency level defaults to ONE for all write and read operations</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.write_consistency_level</td>
+			<td>CASSANDRA_WRITE_CONSISTENCY_LEVEL</td>
+			<td>ONE</td>
+			<td> Consistency levels in Cassandra can be configured to manage availability versus data accuracy. The consistency level defaults to ONE for all write and read operations</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.default_fetch_size</td>
+			<td>CASSANDRA_DEFAULT_FETCH_SIZE</td>
+			<td>2000</td>
+			<td> The fetch size specifies how many rows will be returned at once by Cassandra (in other words, it’s the size of each page)</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.ts_key_value_partitioning</td>
+			<td>TS_KV_PARTITIONING</td>
+			<td>MONTHS</td>
+			<td> Specify partitioning size for timestamp key-value storage. Example: MINUTES, HOURS, DAYS, MONTHS, INDEFINITE</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.use_ts_key_value_partitioning_on_read</td>
+			<td>USE_TS_KV_PARTITIONING_ON_READ</td>
+			<td>true</td>
+			<td> Enable/Disable timestamp key-value partioning on read queries</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.ts_key_value_partitions_max_cache_size</td>
+			<td>TS_KV_PARTITIONS_MAX_CACHE_SIZE</td>
+			<td>100000</td>
+			<td> The number of partitions that are cached in memory of each service. It is useful to decrease the load of re-inserting the same partitions again</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.ts_key_value_ttl</td>
+			<td>TS_KV_TTL</td>
+			<td>0</td>
+			<td> Timeseries Time To Live (in seconds) for Cassandra Record. 0 - record has never expired</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.buffer_size</td>
+			<td>CASSANDRA_QUERY_BUFFER_SIZE</td>
+			<td>200000</td>
+			<td> Maximum number of Cassandra queries that are waiting for execution</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.concurrent_limit</td>
+			<td>CASSANDRA_QUERY_CONCURRENT_LIMIT</td>
+			<td>1000</td>
+			<td> Maximum number of concurrent Cassandra queries</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.permit_max_wait_time</td>
+			<td>PERMIT_MAX_WAIT_TIME</td>
+			<td>120000</td>
+			<td> Max time in milliseconds query waits for execution</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.dispatcher_threads</td>
+			<td>CASSANDRA_QUERY_DISPATCHER_THREADS</td>
+			<td>2</td>
+			<td> Amount of threads to dispatch cassandra queries</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.callback_threads</td>
+			<td>CASSANDRA_QUERY_CALLBACK_THREADS</td>
+			<td>4</td>
+			<td> Buffered rate executor (read, write) for managing I/O rate. See "nosql-*-callback" threads in JMX</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.result_processing_threads</td>
+			<td>CASSANDRA_QUERY_RESULT_PROCESSING_THREADS</td>
+			<td>50</td>
+			<td> Result set transformer and processing. See "cassandra-callback" threads in JMX</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.poll_ms</td>
+			<td>CASSANDRA_QUERY_POLL_MS</td>
+			<td>50</td>
+			<td> Cassandra query queue polling interval in milliseconds</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.rate_limit_print_interval_ms</td>
+			<td>CASSANDRA_QUERY_RATE_LIMIT_PRINT_MS</td>
+			<td>10000</td>
+			<td> Interval in milliseconds for printing Cassandra query queue statistic</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.set_null_values_enabled</td>
+			<td>CASSANDRA_QUERY_SET_NULL_VALUES_ENABLED</td>
+			<td>true</td>
+			<td> set all data type values except target to null for the same ts on save</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.print_queries_freq</td>
+			<td>CASSANDRA_QUERY_PRINT_FREQ</td>
+			<td>0</td>
+			<td> log one of cassandra queries with specified frequency (0 - logging is disabled)</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.tenant_rate_limits.print_tenant_names</td>
+			<td>CASSANDRA_QUERY_TENANT_RATE_LIMITS_PRINT_TENANT_NAMES</td>
+			<td>false</td>
+			<td> Whether to print rate-limited tenant names when printing Cassandra query queue statistic</td>
 		</tr>
 	</tbody>
 </table>
@@ -1230,7 +1551,7 @@
 			<td>actors.rule.chain.debug_mode_rate_limits_per_tenant.configuration</td>
 			<td>ACTORS_RULE_CHAIN_DEBUG_MODE_RATE_LIMITS_PER_TENANT_CONFIGURATION</td>
 			<td>50000:3600</td>
-			<td> The value of DEBUG mode rate limit. By default, no more then 50 thousand events per hour</td>
+			<td> The value of DEBUG mode rate limit. By default, no more than 50 thousand events per hour</td>
 		</tr>
 		<tr>
 			<td>actors.rule.node.error_persist_frequency</td>
@@ -1276,6 +1597,21 @@
 			<td> Time in milliseconds for RPC to receive a response after delivery. Used only for SEQUENTIAL_ON_RESPONSE_FROM_DEVICE submit strategy.</td>
 		</tr>
 		<tr>
+			<td>actors.rpc.close_session_on_rpc_delivery_timeout</td>
+			<td>ACTORS_RPC_CLOSE_SESSION_ON_RPC_DELIVERY_TIMEOUT</td>
+			<td>false</td>
+			<td> Close transport session if RPC delivery timed out. If enabled, RPC will be reverted to the queued state.
+ Note:
+ - For MQTT transport:
+   - QoS level 0: This feature does not apply, as no acknowledgment is expected, and therefore no timeout is triggered.
+   - QoS level 1: This feature applies, as an acknowledgment is expected.
+   - QoS level 2: Unsupported.
+ - For CoAP transport:
+   - Confirmable requests: This feature applies, as delivery confirmation is expected.
+   - Non-confirmable requests: This feature does not apply, as no delivery acknowledgment is expected.
+ - For HTTP and SNPM transports: RPC is considered delivered immediately, and there is no logic to await acknowledgment.</td>
+		</tr>
+		<tr>
 			<td>actors.statistics.enabled</td>
 			<td>ACTORS_STATISTICS_ENABLED</td>
 			<td>true</td>
@@ -1292,6 +1628,13 @@
 			<td>ACTORS_STATISTICS_PERSIST_FREQUENCY</td>
 			<td>3600000</td>
 			<td> Actors statistic persistence frequency in milliseconds</td>
+		</tr>
+		<tr>
+			<td>debug.settings.default_duration</td>
+			<td>DEBUG_SETTINGS_DEFAULT_DURATION_MINUTES</td>
+			<td>15</td>
+			<td> Default duration (in minutes) for debug mode. Min value is 1 minute. Tenant profile settings override this one.
+ If value from this setting is invalid, the default value (15 minutes) will be used.</td>
 		</tr>
 	</tbody>
 </table>
@@ -1628,7 +1971,7 @@
 		<tr>
 			<td>cache.specs.relatedEdges.maxSize</td>
 			<td>CACHE_SPECS_RELATED_EDGES_MAX_SIZE</td>
-			<td>10000</td>
+			<td>0</td>
 			<td> 0 means the cache is disabled</td>
 		</tr>
 		<tr>
@@ -1740,13 +2083,13 @@
 			<td> 0 means the cache is disabled</td>
 		</tr>
 		<tr>
-			<td>cache.specs.mobileAppSettings.timeToLiveInMinutes</td>
+			<td>cache.specs.qrCodeSettings.timeToLiveInMinutes</td>
 			<td>CACHE_SPECS_MOBILE_APP_SETTINGS_TTL</td>
 			<td>1440</td>
-			<td> Mobile application cache TTL</td>
+			<td> Qr code settings cache TTL</td>
 		</tr>
 		<tr>
-			<td>cache.specs.mobileAppSettings.maxSize</td>
+			<td>cache.specs.qrCodeSettings.maxSize</td>
 			<td>CACHE_SPECS_MOBILE_APP_SETTINGS_MAX_SIZE</td>
 			<td>10000</td>
 			<td> 0 means the cache is disabled</td>
@@ -3439,6 +3782,30 @@
 			<td>60000</td>
 			<td> Interval of transport statistics logging</td>
 		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.enabled</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_ENABLED</td>
+			<td>true</td>
+			<td> Enable/disable gateways dashboard sync with git repository</td>
+		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.repository_url</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_REPOSITORY_URL</td>
+			<td>https://github.com/thingsboard/gateway-management-extensions-dist.git</td>
+			<td> URL of gateways dashboard repository</td>
+		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.branch</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_BRANCH</td>
+			<td>main</td>
+			<td> Branch of gateways dashboard repository to work with</td>
+		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.fetch_frequency</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_FETCH_FREQUENCY</td>
+			<td>24</td>
+			<td> Fetch frequency in hours for gateways dashboard repository</td>
+		</tr>
 	</tbody>
 </table>
 
@@ -3507,6 +3874,38 @@
  - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
  - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
  - A value that are > 4: MultiNodeConnectionIdGenerator is used</td>
+		</tr>
+		<tr>
+			<td>coap.dtls.max_transmission_unit</td>
+			<td>COAP_DTLS_MAX_TRANSMISSION_UNIT</td>
+			<td>1024</td>
+			<td> Specify the MTU (Maximum Transmission Unit).
+ Should be used if LAN MTU is not used, e.g. if IP tunnels are used or if the client uses a smaller value than the LAN MTU.
+ Default = 1024
+ Minimum value = 64
+ If set to 0 - LAN MTU is used.</td>
+		</tr>
+		<tr>
+			<td>coap.dtls.max_fragment_length</td>
+			<td>COAP_DTLS_MAX_FRAGMENT_LENGTH</td>
+			<td>1024</td>
+			<td> DTLS maximum fragment length (RFC 6066, Section 4).
+ Default = 1024
+ Possible values: 512, 1024, 2048, 4096.
+ If set to 0, the default maximum fragment size of 2^14 bytes (16,384 bytes) is used.
+ Without this extension, TLS specifies a fixed maximum plaintext fragment length of 2^14 bytes.
+ It may be desirable for constrained clients to negotiate a smaller maximum fragment length due to memory limitations or bandwidth limitations.
+ In order to negotiate smaller maximum fragment lengths,
+ clients MAY include an extension of type "max_fragment_length" in the (extended) client hello.
+ The "extension_data" field of this extension SHALL contain:
+ enum {
+   2^9(1) == 512,
+   2^10(2) == 1024,
+   2^11(3) == 2048,
+   2^12(4) == 4096,
+   (255)
+ } MaxFragmentLength;
+ TLS already requires clients and servers to support fragmentation of handshake messages.</td>
 		</tr>
 		<tr>
 			<td>coap.dtls.credentials.type</td>
@@ -3813,19 +4212,19 @@
 		<tr>
 			<td>edges.scheduler_pool_size</td>
 			<td>EDGES_SCHEDULER_POOL_SIZE</td>
-			<td>1</td>
+			<td>4</td>
 			<td> Number of threads that are used to check DB for edge events</td>
 		</tr>
 		<tr>
 			<td>edges.send_scheduler_pool_size</td>
 			<td>EDGES_SEND_SCHEDULER_POOL_SIZE</td>
-			<td>1</td>
+			<td>4</td>
 			<td> Number of threads that are used to send downlink messages to edge over gRPC</td>
 		</tr>
 		<tr>
 			<td>edges.grpc_callback_thread_pool_size</td>
 			<td>EDGES_GRPC_CALLBACK_POOL_SIZE</td>
-			<td>1</td>
+			<td>4</td>
 			<td> Number of threads that are used to convert edge events from DB into downlink messages and send them for delivery</td>
 		</tr>
 		<tr>
@@ -3961,7 +4360,8 @@
 			<td>queue.type</td>
 			<td>TB_QUEUE_TYPE</td>
 			<td>in-memory</td>
-			<td> in-memory or kafka (Apache Kafka) or aws-sqs (AWS SQS) or pubsub (PubSub) or service-bus (Azure Service Bus) or rabbitmq (RabbitMQ)</td>
+			<td> in-memory or kafka (Apache Kafka). The following queue types are deprecated and will no longer be supported in ThingsBoard 4.0:
+ aws-sqs (AWS SQS), pubsub (PubSub), service-bus (Azure Service Bus), rabbitmq (RabbitMQ)</td>
 		</tr>
 		<tr>
 			<td>queue.prefix</td>
@@ -4168,6 +4568,18 @@
 			<td> Example of specific consumer properties value per topic for VC</td>
 		</tr>
 		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_edge_event.notifications.key</td>
+			<td></td>
+			<td>max.poll.records</td>
+			<td> Example of specific consumer properties value per topic for edge event</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_edge_event.notifications.key.value</td>
+			<td>TB_QUEUE_KAFKA_EDGE_EVENT_MAX_POLL_RECORDS</td>
+			<td>50</td>
+			<td> Example of specific consumer properties value per topic for edge event</td>
+		</tr>
+		<tr>
 			<td>queue.kafka.consumer-properties-per-topic.tb_housekeeper.key</td>
 			<td></td>
 			<td>max.poll.records</td>
@@ -4190,6 +4602,30 @@
 			<td>TB_QUEUE_KAFKA_HOUSEKEEPER_REPROCESSING_MAX_POLL_RECORDS</td>
 			<td>1</td>
 			<td> Amount of records to be returned in a single poll. For Housekeeper reprocessing topic, we should consume messages (tasks) one by one</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event.key</td>
+			<td></td>
+			<td>max.poll.records</td>
+			<td> Consumer properties for Kafka tb_cloud_event topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event.key.value</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_MAX_POLL_RECORDS</td>
+			<td>50</td>
+			<td> Amount of records to be returned in a single poll for cloud event topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event_ts.key</td>
+			<td></td>
+			<td>max.poll.records</td>
+			<td> Consumer properties for Kafka tb_cloud_event_ts topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event_ts.key.value</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_TS_MAX_POLL_RECORDS</td>
+			<td>50</td>
+			<td> Amount of records to be returned in a single poll for cloud event timeseries topic</td>
 		</tr>
 		<tr>
 			<td>queue.kafka.other-inline</td>
@@ -4256,6 +4692,24 @@
 			<td>TB_QUEUE_KAFKA_EDGE_TOPIC_PROPERTIES</td>
 			<td>retention.ms:604800000;segment.bytes:52428800;retention.bytes:1048576000;partitions:1;min.insync.replicas:1</td>
 			<td> Kafka properties for Edge topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.topic-properties.edge-event</td>
+			<td>TB_QUEUE_KAFKA_EDGE_EVENT_TOPIC_PROPERTIES</td>
+			<td>retention.ms:2592000000;segment.bytes:52428800;retention.bytes:1048576000;partitions:1;min.insync.replicas:1</td>
+			<td> Kafka properties for Edge event topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.topic-properties.cloud_event</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_TOPIC_PROPERTIES</td>
+			<td>retention.ms:2678400000;segment.bytes:52428800;retention.bytes:1048576000;partitions:1;min.insync.replicas:1</td>
+			<td> Kafka properties for CloudEvent topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.topic-properties.cloud_event_ts</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_TS_TOPIC_PROPERTIES</td>
+			<td>retention.ms:2678400000;segment.bytes:52428800;retention.bytes:10485760000;partitions:1;min.insync.replicas:1</td>
+			<td> Kafka properties for TsCloudEvent topic</td>
 		</tr>
 		<tr>
 			<td>queue.kafka.consumer-stats.enabled</td>
@@ -4960,6 +5414,30 @@
 			<td>TB_QUEUE_EDGE_STATS_PRINT_INTERVAL_MS</td>
 			<td>60000</td>
 			<td> Statistics printing interval for Edge services</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event.topic</td>
+			<td>TB_QUEUE_CLOUD_EVENT_TOPIC</td>
+			<td>tb_cloud_event</td>
+			<td> Default topic name for Kafka, RabbitMQ, etc.</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event.poll-interval</td>
+			<td>TB_QUEUE_CLOUD_EVENT_POLL_INTERVAL_MS</td>
+			<td>25</td>
+			<td> Poll interval for topics related to Cloud Event services</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event-ts.topic</td>
+			<td>TB_QUEUE_CLOUD_EVENT_TS_TOPIC</td>
+			<td>tb_cloud_event_ts</td>
+			<td> Default topic name for Kafka, RabbitMQ, etc.</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event-ts.poll-interval</td>
+			<td>TB_QUEUE_CLOUD_EVENT_TS_POLL_INTERVAL_MS</td>
+			<td>25</td>
+			<td> Poll interval for topics related to Cloud Event services</td>
 		</tr>
 	</tbody>
 </table>

--- a/_includes/docs/pe/edge/user-guide/install/config.md
+++ b/_includes/docs/pe/edge/user-guide/install/config.md
@@ -179,6 +179,12 @@
 			<td> Per-user rate limit for WS subscriptions</td>
 		</tr>
 		<tr>
+			<td>server.ws.alarms_per_alarm_status_subscription_cache_size</td>
+			<td>TB_ALARMS_PER_ALARM_STATUS_SUBSCRIPTION_CACHE_SIZE</td>
+			<td>10</td>
+			<td> Maximum number of active originator alarm ids being saved in cache for single alarm status subscription. For example, no more than 10 alarm ids on the alarm widget</td>
+		</tr>
+		<tr>
 			<td>server.rest.server_side_rpc.min_timeout</td>
 			<td>MIN_SERVER_SIDE_RPC_TIMEOUT</td>
 			<td>5000</td>
@@ -643,8 +649,14 @@
 		<tr>
 			<td>ui.help.base-url</td>
 			<td>UI_HELP_BASE_URL</td>
-			<td>https://raw.githubusercontent.com/thingsboard/thingsboard-pe-ui-help/release-3.8</td>
+			<td>https://raw.githubusercontent.com/thingsboard/thingsboard-pe-ui-help/release-3.9</td>
 			<td> Base URL for UI help assets</td>
+		</tr>
+		<tr>
+			<td>ui.solution_templates.docs_base_url</td>
+			<td>UI_SOLUTION_TEMPLATES_DOCS_BASE_URL</td>
+			<td>https://thingsboard.io/docs/pe</td>
+			<td> Base URL for solution templates docs</td>
 		</tr>
 	</tbody>
 </table>
@@ -669,13 +681,328 @@
 			<td>database.ts.type</td>
 			<td>DATABASE_TS_TYPE</td>
 			<td>sql</td>
-			<td> sql or timescale (for hybrid mode, DATABASE_TS_TYPE value should be timescale)</td>
+			<td> cassandra or sql. timescale option is deprecated and will no longer be supported in ThingsBoard 4.0</td>
 		</tr>
 		<tr>
 			<td>database.ts_latest.type</td>
 			<td>DATABASE_TS_LATEST_TYPE</td>
 			<td>sql</td>
-			<td> sql or timescale (for hybrid mode, DATABASE_TS_TYPE value should be timescale)</td>
+			<td> cassandra or sql. timescale option is deprecated and will no longer be supported in ThingsBoard 4.0</td>
+		</tr>
+	</tbody>
+</table>
+
+
+####  Cassandra driver configuration parameters
+
+<table>
+	<thead>
+		<tr>
+			<td style="width: 25%"><b>Parameter</b></td><td style="width: 30%"><b>Environment Variable</b></td><td style="width: 15%"><b>Default Value</b></td><td style="width: 30%"><b>Description</b></td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>cassandra.cluster_name</td>
+			<td>CASSANDRA_CLUSTER_NAME</td>
+			<td>Thingsboard Edge Cluster</td>
+			<td> Thingsboard Edge cluster name</td>
+		</tr>
+		<tr>
+			<td>cassandra.keyspace_name</td>
+			<td>CASSANDRA_KEYSPACE_NAME</td>
+			<td>thingsboard</td>
+			<td> Thingsboard Edge keyspace name</td>
+		</tr>
+		<tr>
+			<td>cassandra.url</td>
+			<td>CASSANDRA_URL</td>
+			<td>127.0.0.1:9042</td>
+			<td> Specify node list</td>
+		</tr>
+		<tr>
+			<td>cassandra.local_datacenter</td>
+			<td>CASSANDRA_LOCAL_DATACENTER</td>
+			<td>datacenter1</td>
+			<td> Specify the local data center name</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.enabled</td>
+			<td>CASSANDRA_USE_SSL</td>
+			<td>false</td>
+			<td> Enable/disable secure connection</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.hostname_validation</td>
+			<td>CASSANDRA_SSL_HOSTNAME_VALIDATION</td>
+			<td>true</td>
+			<td> Enable/disable validation of Cassandra server hostname
+ If enabled, the hostname of the Cassandra server must match the CN of the server certificate</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.trust_store</td>
+			<td>CASSANDRA_SSL_TRUST_STORE</td>
+			<td></td>
+			<td> Set trust store for client authentication of the server (optional, uses trust store from default SSLContext if not set)</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.trust_store_password</td>
+			<td>CASSANDRA_SSL_TRUST_STORE_PASSWORD</td>
+			<td></td>
+			<td> The password for Cassandra trust store key</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.key_store</td>
+			<td>CASSANDRA_SSL_KEY_STORE</td>
+			<td></td>
+			<td> Set key store for server authentication of the client (optional, uses key store from default SSLContext if not set)
+ A key store is only needed if the Cassandra server requires client authentication</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.key_store_password</td>
+			<td>CASSANDRA_SSL_KEY_STORE_PASSWORD</td>
+			<td></td>
+			<td> The password for the Cassandra key store</td>
+		</tr>
+		<tr>
+			<td>cassandra.ssl.cipher_suites</td>
+			<td>CASSANDRA_SSL_CIPHER_SUITES</td>
+			<td></td>
+			<td> Comma-separated list of cipher suites (optional, uses Java default cipher suites if not set)</td>
+		</tr>
+		<tr>
+			<td>cassandra.jmx</td>
+			<td>CASSANDRA_USE_JMX</td>
+			<td>false</td>
+			<td> Enable/disable JMX</td>
+		</tr>
+		<tr>
+			<td>cassandra.metrics</td>
+			<td>CASSANDRA_USE_METRICS</td>
+			<td>false</td>
+			<td> Enable/disable metrics collection.</td>
+		</tr>
+		<tr>
+			<td>cassandra.compression</td>
+			<td>CASSANDRA_COMPRESSION</td>
+			<td>none</td>
+			<td> NONE SNAPPY LZ4</td>
+		</tr>
+		<tr>
+			<td>cassandra.init_timeout_ms</td>
+			<td>CASSANDRA_CLUSTER_INIT_TIMEOUT_MS</td>
+			<td>300000</td>
+			<td> Specify cassandra cluster initialization timeout in milliseconds (if no hosts are available during startup)</td>
+		</tr>
+		<tr>
+			<td>cassandra.init_retry_interval_ms</td>
+			<td>CASSANDRA_CLUSTER_INIT_RETRY_INTERVAL_MS</td>
+			<td>3000</td>
+			<td> Specify cassandra cluster initialization retry interval (if no hosts available during startup)</td>
+		</tr>
+		<tr>
+			<td>cassandra.max_requests_per_connection_local</td>
+			<td>CASSANDRA_MAX_REQUESTS_PER_CONNECTION_LOCAL</td>
+			<td>32768</td>
+			<td> Cassandra max local requests per connection</td>
+		</tr>
+		<tr>
+			<td>cassandra.max_requests_per_connection_remote</td>
+			<td>CASSANDRA_MAX_REQUESTS_PER_CONNECTION_REMOTE</td>
+			<td>32768</td>
+			<td> Cassandra max remote requests per connection</td>
+		</tr>
+		<tr>
+			<td>cassandra.credentials</td>
+			<td>CASSANDRA_USE_CREDENTIALS</td>
+			<td>false</td>
+			<td> Credential parameters</td>
+		</tr>
+		<tr>
+			<td>cassandra.username</td>
+			<td>CASSANDRA_USERNAME</td>
+			<td></td>
+			<td> Specify your username</td>
+		</tr>
+		<tr>
+			<td>cassandra.password</td>
+			<td>CASSANDRA_PASSWORD</td>
+			<td></td>
+			<td> Specify your password</td>
+		</tr>
+		<tr>
+			<td>cassandra.cloud.secure_connect_bundle_path</td>
+			<td>CASSANDRA_CLOUD_SECURE_BUNDLE_PATH</td>
+			<td></td>
+			<td> /etc/thingsboard/astra/secure-connect-thingsboard.zip</td>
+		</tr>
+		<tr>
+			<td>cassandra.cloud.client_id</td>
+			<td>CASSANDRA_CLOUD_CLIENT_ID</td>
+			<td></td>
+			<td> DucitQPHMzPCBOZqFYexAfKk</td>
+		</tr>
+		<tr>
+			<td>cassandra.cloud.client_secret</td>
+			<td>CASSANDRA_CLOUD_CLIENT_SECRET</td>
+			<td></td>
+			<td> ZnF7FpuHp43FP5BzM+KY8wGmSb4Ql6BhT4Z7sOU13ze+gXQ-n7OkFpNuB,oACUIQObQnK0g4bSPoZhK5ejkcF9F.j6f64j71Sr.tiRe0Fsq2hPS1ZCGSfAaIgg63IydG</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.connect_timeout</td>
+			<td>CASSANDRA_SOCKET_TIMEOUT</td>
+			<td>5000</td>
+			<td> Sets the timeout, in milliseconds, of a native connection from ThingsBoard to Cassandra. The default value is 5000</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.read_timeout</td>
+			<td>CASSANDRA_SOCKET_READ_TIMEOUT</td>
+			<td>20000</td>
+			<td> Timeout before closing the connection. Value set in milliseconds</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.keep_alive</td>
+			<td>CASSANDRA_SOCKET_KEEP_ALIVE</td>
+			<td>true</td>
+			<td> Gets if TCP keep-alive must be used</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.reuse_address</td>
+			<td>CASSANDRA_SOCKET_REUSE_ADDRESS</td>
+			<td>true</td>
+			<td> Enable/Disable reuse-address. The socket option allows for the reuse of local addresses and ports</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.so_linger</td>
+			<td>CASSANDRA_SOCKET_SO_LINGER</td>
+			<td></td>
+			<td> Sets the linger-on-close timeout. By default, this option is not set by the driver. The actual value will be the default from the underlying Netty transport</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.tcp_no_delay</td>
+			<td>CASSANDRA_SOCKET_TCP_NO_DELAY</td>
+			<td>false</td>
+			<td> Enable/Disable Nagle's algorithm</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.receive_buffer_size</td>
+			<td>CASSANDRA_SOCKET_RECEIVE_BUFFER_SIZE</td>
+			<td></td>
+			<td> Sets a hint to the size of the underlying buffers for incoming network I/O. By default, this option is not set by the driver. The actual value will be the default from the underlying Netty transport</td>
+		</tr>
+		<tr>
+			<td>cassandra.socket.send_buffer_size</td>
+			<td>CASSANDRA_SOCKET_SEND_BUFFER_SIZE</td>
+			<td></td>
+			<td> Returns the hint to the size of the underlying buffers for outgoing network I/O. By default, this option is not set by the driver. The actual value will be the default from the underlying Netty transport</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.read_consistency_level</td>
+			<td>CASSANDRA_READ_CONSISTENCY_LEVEL</td>
+			<td>ONE</td>
+			<td> Consistency levels in Cassandra can be configured to manage availability versus data accuracy. The consistency level defaults to ONE for all write and read operations</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.write_consistency_level</td>
+			<td>CASSANDRA_WRITE_CONSISTENCY_LEVEL</td>
+			<td>ONE</td>
+			<td> Consistency levels in Cassandra can be configured to manage availability versus data accuracy. The consistency level defaults to ONE for all write and read operations</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.default_fetch_size</td>
+			<td>CASSANDRA_DEFAULT_FETCH_SIZE</td>
+			<td>2000</td>
+			<td> The fetch size specifies how many rows will be returned at once by Cassandra (in other words, it’s the size of each page)</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.ts_key_value_partitioning</td>
+			<td>TS_KV_PARTITIONING</td>
+			<td>MONTHS</td>
+			<td> Specify partitioning size for timestamp key-value storage. Example: MINUTES, HOURS, DAYS, MONTHS, INDEFINITE</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.use_ts_key_value_partitioning_on_read</td>
+			<td>USE_TS_KV_PARTITIONING_ON_READ</td>
+			<td>true</td>
+			<td> Enable/Disable timestamp key-value partioning on read queries</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.ts_key_value_partitions_max_cache_size</td>
+			<td>TS_KV_PARTITIONS_MAX_CACHE_SIZE</td>
+			<td>100000</td>
+			<td> The number of partitions that are cached in memory of each service. It is useful to decrease the load of re-inserting the same partitions again</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.ts_key_value_ttl</td>
+			<td>TS_KV_TTL</td>
+			<td>0</td>
+			<td> Timeseries Time To Live (in seconds) for Cassandra Record. 0 - record has never expired</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.buffer_size</td>
+			<td>CASSANDRA_QUERY_BUFFER_SIZE</td>
+			<td>200000</td>
+			<td> Maximum number of Cassandra queries that are waiting for execution</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.concurrent_limit</td>
+			<td>CASSANDRA_QUERY_CONCURRENT_LIMIT</td>
+			<td>1000</td>
+			<td> Maximum number of concurrent Cassandra queries</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.permit_max_wait_time</td>
+			<td>PERMIT_MAX_WAIT_TIME</td>
+			<td>120000</td>
+			<td> Max time in milliseconds query waits for execution</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.dispatcher_threads</td>
+			<td>CASSANDRA_QUERY_DISPATCHER_THREADS</td>
+			<td>2</td>
+			<td> Amount of threads to dispatch cassandra queries</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.callback_threads</td>
+			<td>CASSANDRA_QUERY_CALLBACK_THREADS</td>
+			<td>4</td>
+			<td> Buffered rate executor (read, write) for managing I/O rate. See "nosql-*-callback" threads in JMX</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.result_processing_threads</td>
+			<td>CASSANDRA_QUERY_RESULT_PROCESSING_THREADS</td>
+			<td>50</td>
+			<td> Result set transformer and processing. See "cassandra-callback" threads in JMX</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.poll_ms</td>
+			<td>CASSANDRA_QUERY_POLL_MS</td>
+			<td>50</td>
+			<td> Cassandra query queue polling interval in milliseconds</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.rate_limit_print_interval_ms</td>
+			<td>CASSANDRA_QUERY_RATE_LIMIT_PRINT_MS</td>
+			<td>10000</td>
+			<td> Interval in milliseconds for printing Cassandra query queue statistic</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.set_null_values_enabled</td>
+			<td>CASSANDRA_QUERY_SET_NULL_VALUES_ENABLED</td>
+			<td>true</td>
+			<td> set all data type values except target to null for the same ts on save</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.print_queries_freq</td>
+			<td>CASSANDRA_QUERY_PRINT_FREQ</td>
+			<td>0</td>
+			<td> log one of cassandra queries with specified frequency (0 - logging is disabled)</td>
+		</tr>
+		<tr>
+			<td>cassandra.query.tenant_rate_limits.print_tenant_names</td>
+			<td>CASSANDRA_QUERY_TENANT_RATE_LIMITS_PRINT_TENANT_NAMES</td>
+			<td>false</td>
+			<td> Whether to print rate-limited tenant names when printing Cassandra query queue statistic</td>
 		</tr>
 	</tbody>
 </table>
@@ -1254,7 +1581,7 @@
 			<td>actors.rule.chain.debug_mode_rate_limits_per_tenant.configuration</td>
 			<td>ACTORS_RULE_CHAIN_DEBUG_MODE_RATE_LIMITS_PER_TENANT_CONFIGURATION</td>
 			<td>50000:3600</td>
-			<td> The value of DEBUG mode rate limit. By default, no more then 50 thousand events per hour</td>
+			<td> The value of DEBUG mode rate limit. By default, no more than 50 thousand events per hour</td>
 		</tr>
 		<tr>
 			<td>actors.rule.node.error_persist_frequency</td>
@@ -1301,6 +1628,21 @@
 			<td> Time in milliseconds for RPC to receive a response after delivery. Used only for SEQUENTIAL_ON_RESPONSE_FROM_DEVICE submit strategy.</td>
 		</tr>
 		<tr>
+			<td>actors.rpc.close_session_on_rpc_delivery_timeout</td>
+			<td>ACTORS_RPC_CLOSE_SESSION_ON_RPC_DELIVERY_TIMEOUT</td>
+			<td>false</td>
+			<td> Close transport session if RPC delivery timed out. If enabled, RPC will be reverted to the queued state.
+ Note:
+ - For MQTT transport:
+   - QoS level 0: This feature does not apply, as no acknowledgment is expected, and therefore no timeout is triggered.
+   - QoS level 1: This feature applies, as an acknowledgment is expected.
+   - QoS level 2: Unsupported.
+ - For CoAP transport:
+   - Confirmable requests: This feature applies, as delivery confirmation is expected.
+   - Non-confirmable requests: This feature does not apply, as no delivery acknowledgment is expected.
+ - For HTTP and SNPM transports: RPC is considered delivered immediately, and there is no logic to await acknowledgment.</td>
+		</tr>
+		<tr>
 			<td>actors.statistics.enabled</td>
 			<td>ACTORS_STATISTICS_ENABLED</td>
 			<td>true</td>
@@ -1317,6 +1659,13 @@
 			<td>ACTORS_STATISTICS_PERSIST_FREQUENCY</td>
 			<td>3600000</td>
 			<td> Actors statistic persistence frequency in milliseconds</td>
+		</tr>
+		<tr>
+			<td>debug.settings.default_duration</td>
+			<td>DEBUG_SETTINGS_DEFAULT_DURATION_MINUTES</td>
+			<td>15</td>
+			<td> Default duration (in minutes) for debug mode. Min value is 1 minute. Tenant profile settings override this one.
+ If value from this setting is invalid, the default value (15 minutes) will be used.</td>
 		</tr>
 	</tbody>
 </table>
@@ -1439,6 +1788,12 @@
 			<td>TB_INTEGRATIONS_CONVERTERS_LIBRARY_REPO_URL</td>
 			<td>https://github.com/thingsboard/data-converters.git</td>
 			<td> URL of the data converters repository</td>
+		</tr>
+		<tr>
+			<td>integrations.converters.library.branch</td>
+			<td>TB_INTEGRATIONS_CONVERTERS_LIBRARY_REPO_BRANCH</td>
+			<td>main</td>
+			<td> Branch of the data converters repository to use</td>
 		</tr>
 		<tr>
 			<td>integrations.converters.library.fetch_frequency</td>
@@ -1824,7 +2179,7 @@
 		<tr>
 			<td>cache.specs.relatedEdges.maxSize</td>
 			<td>CACHE_SPECS_RELATED_EDGES_MAX_SIZE</td>
-			<td>10000</td>
+			<td>0</td>
 			<td> 0 means the cache is disabled</td>
 		</tr>
 		<tr>
@@ -1936,13 +2291,13 @@
 			<td> 0 means the cache is disabled</td>
 		</tr>
 		<tr>
-			<td>cache.specs.mobileAppSettings.timeToLiveInMinutes</td>
+			<td>cache.specs.qrCodeSettings.timeToLiveInMinutes</td>
 			<td>CACHE_SPECS_MOBILE_APP_SETTINGS_TTL</td>
 			<td>1440</td>
-			<td> Mobile application cache TTL</td>
+			<td> Qr code settings cache TTL</td>
 		</tr>
 		<tr>
-			<td>cache.specs.mobileAppSettings.maxSize</td>
+			<td>cache.specs.qrCodeSettings.maxSize</td>
 			<td>CACHE_SPECS_MOBILE_APP_SETTINGS_MAX_SIZE</td>
 			<td>10000</td>
 			<td> 0 means the cache is disabled</td>
@@ -3821,6 +4176,30 @@
 			<td>60000</td>
 			<td> Interval of transport statistics logging</td>
 		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.enabled</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_ENABLED</td>
+			<td>true</td>
+			<td> Enable/disable gateways dashboard sync with git repository</td>
+		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.repository_url</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_REPOSITORY_URL</td>
+			<td>https://github.com/thingsboard/gateway-management-extensions-dist.git</td>
+			<td> URL of gateways dashboard repository</td>
+		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.branch</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_BRANCH</td>
+			<td>main</td>
+			<td> Branch of gateways dashboard repository to work with</td>
+		</tr>
+		<tr>
+			<td>transport.gateway.dashboard.sync.fetch_frequency</td>
+			<td>TB_GATEWAY_DASHBOARD_SYNC_FETCH_FREQUENCY</td>
+			<td>24</td>
+			<td> Fetch frequency in hours for gateways dashboard repository</td>
+		</tr>
 	</tbody>
 </table>
 
@@ -3889,6 +4268,38 @@
  - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
  - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
  - A value that are > 4: MultiNodeConnectionIdGenerator is used</td>
+		</tr>
+		<tr>
+			<td>coap.dtls.max_transmission_unit</td>
+			<td>COAP_DTLS_MAX_TRANSMISSION_UNIT</td>
+			<td>1024</td>
+			<td> Specify the MTU (Maximum Transmission Unit).
+ Should be used if LAN MTU is not used, e.g. if IP tunnels are used or if the client uses a smaller value than the LAN MTU.
+ Default = 1024
+ Minimum value = 64
+ If set to 0 - LAN MTU is used.</td>
+		</tr>
+		<tr>
+			<td>coap.dtls.max_fragment_length</td>
+			<td>COAP_DTLS_MAX_FRAGMENT_LENGTH</td>
+			<td>1024</td>
+			<td> DTLS maximum fragment length (RFC 6066, Section 4).
+ Default = 1024
+ Possible values: 512, 1024, 2048, 4096.
+ If set to 0, the default maximum fragment size of 2^14 bytes (16,384 bytes) is used.
+ Without this extension, TLS specifies a fixed maximum plaintext fragment length of 2^14 bytes.
+ It may be desirable for constrained clients to negotiate a smaller maximum fragment length due to memory limitations or bandwidth limitations.
+ In order to negotiate smaller maximum fragment lengths,
+ clients MAY include an extension of type "max_fragment_length" in the (extended) client hello.
+ The "extension_data" field of this extension SHALL contain:
+ enum {
+   2^9(1) == 512,
+   2^10(2) == 1024,
+   2^11(3) == 2048,
+   2^12(4) == 4096,
+   (255)
+ } MaxFragmentLength;
+ TLS already requires clients and servers to support fragmentation of handshake messages.</td>
 		</tr>
 		<tr>
 			<td>coap.dtls.credentials.type</td>
@@ -4195,19 +4606,19 @@
 		<tr>
 			<td>edges.scheduler_pool_size</td>
 			<td>EDGES_SCHEDULER_POOL_SIZE</td>
-			<td>1</td>
+			<td>4</td>
 			<td> Number of threads that are used to check DB for edge events</td>
 		</tr>
 		<tr>
 			<td>edges.send_scheduler_pool_size</td>
 			<td>EDGES_SEND_SCHEDULER_POOL_SIZE</td>
-			<td>1</td>
+			<td>4</td>
 			<td> Number of threads that are used to send downlink messages to edge over gRPC</td>
 		</tr>
 		<tr>
 			<td>edges.grpc_callback_thread_pool_size</td>
 			<td>EDGES_GRPC_CALLBACK_POOL_SIZE</td>
-			<td>1</td>
+			<td>4</td>
 			<td> Number of threads that are used to convert edge events from DB into downlink messages and send them for delivery</td>
 		</tr>
 		<tr>
@@ -4262,7 +4673,7 @@
 		</tr>
 		<tr>
 			<td>swagger.exclude_api_path</td>
-			<td>SWAGGER_API_PATH</td>
+			<td>SWAGGER_EXCLUDE_API_PATH</td>
 			<td>/api/v1/integrations/**</td>
 			<td> Excluded API path match pattern of swagger UI links</td>
 		</tr>
@@ -4332,14 +4743,6 @@
 			<td>thingsboard</td>
 			<td> The group name (definition) on the API doc UI page.</td>
 		</tr>
-		<tr>
-			<td>edge_license.instance_data_file</td>
-			<td>EDGE_LICENSE_INSTANCE_DATA_FILE</td>
-			<td>instance-edge-license.data</td>
-			<td> Instance data is auto-generated and is used to identify particular ThingsBoard Edge Instance.
- Instance data is periodically updated and stored into the specified file which can be set to absolute or relative path.
- Please make sure that thingsboard edge process has access to the instance data file, in case you use absolute path.</td>
-		</tr>
 	</tbody>
 </table>
 
@@ -4357,7 +4760,8 @@
 			<td>queue.type</td>
 			<td>TB_QUEUE_TYPE</td>
 			<td>in-memory</td>
-			<td> in-memory or kafka (Apache Kafka) or aws-sqs (AWS SQS) or pubsub (PubSub) or service-bus (Azure Service Bus) or rabbitmq (RabbitMQ)</td>
+			<td> in-memory or kafka (Apache Kafka). The following queue types are deprecated and will no longer be supported in ThingsBoard 4.0:
+ aws-sqs (AWS SQS), pubsub (PubSub), service-bus (Azure Service Bus), rabbitmq (RabbitMQ)</td>
 		</tr>
 		<tr>
 			<td>queue.prefix</td>
@@ -4564,6 +4968,18 @@
 			<td> Example of specific consumer properties value per topic for VC</td>
 		</tr>
 		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_edge_event.notifications.key</td>
+			<td></td>
+			<td>max.poll.records</td>
+			<td> Example of specific consumer properties value per topic for edge event</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_edge_event.notifications.key.value</td>
+			<td>TB_QUEUE_KAFKA_EDGE_EVENT_MAX_POLL_RECORDS</td>
+			<td>50</td>
+			<td> Example of specific consumer properties value per topic for edge event</td>
+		</tr>
+		<tr>
 			<td>queue.kafka.consumer-properties-per-topic.tb_housekeeper.key</td>
 			<td></td>
 			<td>max.poll.records</td>
@@ -4586,6 +5002,30 @@
 			<td>TB_QUEUE_KAFKA_HOUSEKEEPER_REPROCESSING_MAX_POLL_RECORDS</td>
 			<td>1</td>
 			<td> Amount of records to be returned in a single poll. For Housekeeper reprocessing topic, we should consume messages (tasks) one by one</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event.key</td>
+			<td></td>
+			<td>max.poll.records</td>
+			<td> Consumer properties for Kafka tb_cloud_event topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event.key.value</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_MAX_POLL_RECORDS</td>
+			<td>50</td>
+			<td> Amount of records to be returned in a single poll for cloud event topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event_ts.key</td>
+			<td></td>
+			<td>max.poll.records</td>
+			<td> Consumer properties for Kafka tb_cloud_event_ts topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.consumer-properties-per-topic.tb_cloud_event_ts.key.value</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_TS_MAX_POLL_RECORDS</td>
+			<td>50</td>
+			<td> Amount of records to be returned in a single poll for cloud event timeseries topic</td>
 		</tr>
 		<tr>
 			<td>queue.kafka.other-inline</td>
@@ -4658,6 +5098,24 @@
 			<td>TB_QUEUE_KAFKA_EDGE_TOPIC_PROPERTIES</td>
 			<td>retention.ms:604800000;segment.bytes:52428800;retention.bytes:1048576000;partitions:1;min.insync.replicas:1</td>
 			<td> Kafka properties for Edge topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.topic-properties.edge-event</td>
+			<td>TB_QUEUE_KAFKA_EDGE_EVENT_TOPIC_PROPERTIES</td>
+			<td>retention.ms:2592000000;segment.bytes:52428800;retention.bytes:1048576000;partitions:1;min.insync.replicas:1</td>
+			<td> Kafka properties for Edge event topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.topic-properties.cloud_event</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_TOPIC_PROPERTIES</td>
+			<td>retention.ms:2678400000;segment.bytes:52428800;retention.bytes:1048576000;partitions:1;min.insync.replicas:1</td>
+			<td> Kafka properties for CloudEvent topic</td>
+		</tr>
+		<tr>
+			<td>queue.kafka.topic-properties.cloud_event_ts</td>
+			<td>TB_QUEUE_KAFKA_CLOUD_EVENT_TS_TOPIC_PROPERTIES</td>
+			<td>retention.ms:2678400000;segment.bytes:52428800;retention.bytes:10485760000;partitions:1;min.insync.replicas:1</td>
+			<td> Kafka properties for TsCloudEvent topic</td>
 		</tr>
 		<tr>
 			<td>queue.kafka.consumer-stats.enabled</td>
@@ -5190,6 +5648,12 @@
 			<td> Maximum amount of task reprocessing attempts. After exceeding, the task will be dropped</td>
 		</tr>
 		<tr>
+			<td>queue.core.housekeeper.entities-cleanup-frequency</td>
+			<td>TB_HOUSEKEEPER_ENTITIES_CLEANUP_FREQUENCY</td>
+			<td>3600</td>
+			<td> Expiration check frequency in seconds for entities that have ttl</td>
+		</tr>
+		<tr>
 			<td>queue.core.housekeeper.stats.enabled</td>
 			<td>TB_HOUSEKEEPER_STATS_ENABLED</td>
 			<td>true</td>
@@ -5464,6 +5928,30 @@
 			<td>TB_QUEUE_INTEGRATION_EXECUTOR_RESPONSE_POLL_INTERVAL_MS</td>
 			<td>25</td>
 			<td> Interval in milliseconds to poll api response from integration executor microservices</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event.topic</td>
+			<td>TB_QUEUE_CLOUD_EVENT_TOPIC</td>
+			<td>tb_cloud_event</td>
+			<td> Default topic name for Kafka, RabbitMQ, etc.</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event.poll-interval</td>
+			<td>TB_QUEUE_CLOUD_EVENT_POLL_INTERVAL_MS</td>
+			<td>25</td>
+			<td> Poll interval for topics related to Cloud Event services</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event-ts.topic</td>
+			<td>TB_QUEUE_CLOUD_EVENT_TS_TOPIC</td>
+			<td>tb_cloud_event_ts</td>
+			<td> Default topic name for Kafka, RabbitMQ, etc.</td>
+		</tr>
+		<tr>
+			<td>queue.cloud-event-ts.poll-interval</td>
+			<td>TB_QUEUE_CLOUD_EVENT_TS_POLL_INTERVAL_MS</td>
+			<td>25</td>
+			<td> Poll interval for topics related to Cloud Event services</td>
 		</tr>
 	</tbody>
 </table>

--- a/_includes/templates/edge/bind-port-changed-banner.md
+++ b/_includes/templates/edge/bind-port-changed-banner.md
@@ -1,4 +1,4 @@
 {% capture local-deployment %}
-If you changed the Edge HTTP bind port to 18080 during Edge installation, use the following **ThingsBoard Edge UI** link: `http://localhost:18080`.
+If you changed the **Edge HTTP bind port to 18080** during the Edge installation, use the [http://localhost:18080](http://localhost:18080){: target="_blank"} link to access the **ThingsBoard Edge UI**.
 {% endcapture %}
 {% include templates/info-banner.md content=local-deployment %}

--- a/_includes/templates/edge/create-tb-db-rhel.md
+++ b/_includes/templates/edge/create-tb-db-rhel.md
@@ -1,7 +1,9 @@
+#### Modifying PostgreSQL's Authentication Method (Optional)
 
-After configuring the password, edit the **pg_hba.conf** to use MD5 authentication with the postgres user.
+Since **ThingsBoard Edge** uses the **PostgreSQL** database for local storage, configuring **MD5 authentication** ensures that only authenticated users or applications can access the database, thus protecting your data.
+After configuring the password, edit the **pg_hba.conf** file to use **MD5 hashing** for authentication instead of the default method (**ident**) for local **IPv4 connections**.
 
-Edit pg_hba.conf file: 
+Edit the **pg_hba.conf** file: 
 
 ```bash
 sudo nano /var/lib/pgsql/16/data/pg_hba.conf
@@ -21,25 +23,25 @@ Replace `ident` with `md5`:
 host    all             all             127.0.0.1/32            md5
 ```
 
-Finally, you should restart the PostgreSQL service to initialize the new configuration:
+Finally, restart the **PostgreSQL** service to initialize the new configuration:
 
 ```bash
 sudo systemctl restart postgresql-16.service
 ```
 {: .copy-code}
 
-Connect to the database to create ThingsBoard Edge DB:
+Connect to the database to create **ThingsBoard Edge DB**:
 
 ```bash
 psql -U postgres -d postgres -h 127.0.0.1 -W
 ```
 {: .copy-code}
 
-Execute create database statement:
+Run the following command to create the database:
 
 ```bash
 CREATE DATABASE tb_edge;
 ```
 {: .copy-code}
 
-Press “Ctrl+D” twice to exit PostgreSQL.
+Press **“Ctrl+D”** twice to exit PostgreSQL.

--- a/_includes/templates/edge/docker-queue-in-memory.md
+++ b/_includes/templates/edge/docker-queue-in-memory.md
@@ -1,0 +1,52 @@
+Create docker compose file for ThingsBoard Edge service:
+
+```text
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following lines to the yml file:
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: always
+    image: "thingsboard/tb-edge:{{ site.release.edge_full_ver }}"
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "5683-5688:5683-5688/udp"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+      CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
+      CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
+      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_DB: tb-edge
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - tb-edge-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  tb-edge-data:
+    name: tb-edge-data
+  tb-edge-logs:
+    name: tb-edge-logs
+  tb-edge-postgres-data:
+    name: tb-edge-postgres-data
+```
+{: .copy-code}
+
+{% include templates/edge/install/docker_compose_details_explain.md %}
+
+{% assign serviceName = "tbedge" %}
+{% include templates/install/docker/docker-compose-up.md %}

--- a/_includes/templates/edge/docker-queue-in-memory.md
+++ b/_includes/templates/edge/docker-queue-in-memory.md
@@ -1,11 +1,11 @@
-Create docker compose file for ThingsBoard Edge service:
+Create docker compose file for the **ThingsBoard Edge** service:
 
 ```text
 nano docker-compose.yml
 ```
 {: .copy-code}
 
-Add the following lines to the yml file:
+Add the following lines to the **docker-compose.yml** file:
 
 ```yml
 version: '3.8'

--- a/_includes/templates/edge/install/cassandra-rhel-install.md
+++ b/_includes/templates/edge/install/cassandra-rhel-install.md
@@ -1,0 +1,47 @@
+In order to run Cassandra, install **Java 11**:
+```bash
+sudo apt install openjdk-11-jdk
+```
+{: .copy-code}
+
+Set **Java 17** as the default version (required for ThingsBoard Edge):
+```bash
+sudo update-alternatives --config java
+```
+{: .copy-code}
+
+Add the Cassandra **repository**:
+```bash
+sudo nano /etc/yum.repos.d/cassandra.repo
+```
+{: .copy-code}
+
+Add the following content:
+```ini
+[cassandra]
+name=Apache Cassandra
+baseurl=https://redhat.cassandra.apache.org/50x/
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://downloads.apache.org/cassandra/KEYS
+```
+{: .copy-code}
+* **50x** for Cassandra 5.0 version series.
+
+Update package index if necessary: 
+```bash
+sudo yum update
+```
+{: .copy-code}
+
+Install Cassandra:
+```bash
+sudo yum install cassandra
+```
+{: .copy-code}
+
+Start Cassandra service:
+```bash
+sudo service cassandra start
+```
+{: .copy-code}

--- a/_includes/templates/edge/install/cassandra-ubuntu-install.md
+++ b/_includes/templates/edge/install/cassandra-ubuntu-install.md
@@ -1,0 +1,50 @@
+The instructions listed below will help you to install **Cassandra**.
+
+```bash
+# Add cassandra repository
+echo "deb https://debian.cassandra.apache.org 41x main" | sudo tee /etc/apt/sources.list.d/cassandra.sources.list
+curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
+sudo apt-get update
+## Cassandra installation
+sudo apt-get install cassandra
+## Tools installation
+sudo apt-get install cassandra-tools
+```
+
+In order to run Cassandra, install **Java 11**.
+
+Install the package:
+```bash
+sudo apt install openjdk-11-jdk
+```
+{: .copy-code}
+Set **Java 17** as the default version (required for ThingsBoard Edge):
+```bash
+sudo update-alternatives --config java
+```
+{: .copy-code}
+Edit the Cassandra **configuration file**:
+```bash
+sudo nano /usr/share/cassandra/cassandra.in.sh
+```
+{: .copy-code}
+Find the following line:
+```bash
+# JAVA_HOME can optionally be set here
+#JAVA_HOME=/usr/local/jdk6
+```
+And replace it as follows:
+```bash
+# JAVA_HOME can optionally be set here
+JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+```
+Then, restart Cassandra:
+```bash
+sudo service cassandra stop
+```
+{: .copy-code}
+```bash
+sudo service cassandra start
+```
+{: .copy-code}
+

--- a/_includes/templates/edge/install/docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/docker-queue-hybrid.md
@@ -16,7 +16,7 @@ version: '3.8'
 services:
   mytbedge:
     restart: always
-    image: "thingsboard/tb-edge:3.9.0EDGE"
+    image: "thingsboard/tb-edge:{{ site.release.edge_full_ver }}"
     ports:
       - "8080:8080"
       - "1883:1883"

--- a/_includes/templates/edge/install/docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/docker-queue-hybrid.md
@@ -1,6 +1,6 @@
 [Apache Cassandra](https://cassandra.apache.org/_/index.html){: target="_blank"} is an open source NoSQL database designed to manage massive amounts of data.
 
-[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream-processing software platform.
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
 Create docker compose file for the **ThingsBoard Edge** service:
 

--- a/_includes/templates/edge/install/docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/docker-queue-hybrid.md
@@ -9,7 +9,7 @@ nano docker-compose.yml
 ```
 {: .copy-code}
 
-Add the following lines to the **docker-compose.yml** file:
+Add the following lines to the **docker-compose.yml** file: 
 
 ```yml
 version: '3.8'
@@ -68,11 +68,18 @@ services:
       - kafka-data:/bitnami
   cassandra:
     restart: always
-    image: "cassandra:4.1"
+    image: "cassandra:4.0"
+    container_name: cassandra
+    environment:
+      CASSANDRA_CLUSTER_NAME: "Thingsboard Edge Cluster"
+      CASSANDRA_KEYSPACE_NAME: "tb_edge"
+      CASSANDRA_LOCAL_DATACENTER: "datacenter1"
     ports:
-      - "9042"
+      - 9042:9042
     volumes:
-      - tb-edge-cassandra-data:/var/lib/cassandra
+      - ./data/cassandra:/var/lib/cassandra
+    networks:
+      - cassandra-network
 volumes:
   tb-edge-data:
     name: tb-edge-data
@@ -82,6 +89,9 @@ volumes:
     name: tb-edge-postgres-data
   kafka-data:
     driver: local
+networks:
+  cassandra-network:
+    driver: bridge
 ```
 {: .copy-code}
 

--- a/_includes/templates/edge/install/docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/docker-queue-hybrid.md
@@ -1,4 +1,6 @@
-[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
+[Apache Cassandra](https://cassandra.apache.org/_/index.html){: target="_blank"} is an open source NoSQL database designed to manage massive amounts of data.
+
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream-processing software platform.
 
 Create docker compose file for the **ThingsBoard Edge** service:
 
@@ -26,6 +28,8 @@ services:
       CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
       TB_QUEUE_TYPE: "kafka"
       TB_KAFKA_SERVERS: "kafka:9092"
+      DATABASE_TS_TYPE: "cassandra"
+      CASSANDRA_URL: "cassandra:9042"
     volumes:
       - tb-edge-data:/data
       - tb-edge-logs:/var/log/tb-edge
@@ -62,6 +66,13 @@ services:
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093" #KRaft
     volumes:
       - kafka-data:/bitnami
+  cassandra:
+    restart: always
+    image: "cassandra:4.1"
+    ports:
+      - "9042"
+    volumes:
+      - tb-edge-cassandra-data:/var/lib/cassandra
 volumes:
   tb-edge-data:
     name: tb-edge-data

--- a/_includes/templates/edge/install/docker-queue-kafka.md
+++ b/_includes/templates/edge/install/docker-queue-kafka.md
@@ -14,7 +14,7 @@ version: '3.8'
 services:
   mytbedge:
     restart: always
-    image: "thingsboard/tb-edge:3.9.0EDGE"
+    image: "thingsboard/tb-edge:{{ site.release.edge_full_ver }}"
     ports:
       - "8080:8080"
       - "1883:1883"

--- a/_includes/templates/edge/install/docker-queue-kafka.md
+++ b/_includes/templates/edge/install/docker-queue-kafka.md
@@ -1,0 +1,79 @@
+
+[Apache Kafka](https://kafka.apache.org/) is an open-source stream-processing software platform.
+
+Create docker compose file for the **ThingsBoard Edge** service:
+
+```text
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following lines to the **docker-compose.yml** file:
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: always
+    image: "thingsboard/tb-edge:3.9.0EDGE"
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "5683-5688:5683-5688/udp"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+      CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
+      CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
+      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
+      TB_QUEUE_TYPE: "kafka"
+      TB_KAFKA_SERVERS: "kafka:9092"
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_DB: tb-edge
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - tb-edge-postgres-data:/var/lib/postgresql/data
+  kafka:
+    restart: always
+    image: bitnami/kafka:3.8.1
+    ports:
+      - 9092:9092 #to localhost:9092 from host machine
+      - 9093 #for Kraft
+      - 9094 #to kafka:9094 from within Docker network
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_LISTENERS: "OUTSIDE://:9092,CONTROLLER://:9093,INSIDE://:9094"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "OUTSIDE://localhost:9092,INSIDE://kafka:9094"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "INSIDE"
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker" #KRaft
+      KAFKA_CFG_NODE_ID: "0" #KRaft
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER" #KRaft
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093" #KRaft
+    volumes:
+      - kafka-data:/bitnamivolumes:
+  tb-edge-data:
+    name: tb-edge-data
+  tb-edge-logs:
+    name: tb-edge-logs
+  tb-edge-postgres-data:
+    name: tb-edge-postgres-data
+  kafka-data:
+    driver: local
+```
+{: .copy-code}
+
+{% include templates/edge/install/docker_compose_details_explain.md %}
+
+{% include templates/install/docker/docker-compose-up.md %}

--- a/_includes/templates/edge/install/hardware-requirements.md
+++ b/_includes/templates/edge/install/hardware-requirements.md
@@ -1,7 +1,7 @@
 ### Edge Hardware Requirements
 
-The hardware specifications needed for ThingsBoard Edge are determined by both the number of devices connected locally and the extent of GUI interaction:
+The hardware specifications required for **ThingsBoard Edge** are determined by both the number of locally connected devices and the level of GUI interaction:
 
-- **Light Usage:** If you intend to operate ThingsBoard Edge with minimal GUI interactions (such as local dashboards and device management) and anticipate connecting fewer than 100 devices to a single machine, a minimum of 1GB of RAM should suffice.
+- **Light Usage:** If you intend to operate **ThingsBoard Edge** with minimal GUI interactions (such as local dashboards and device management) and expect to connect fewer than 100 devices to a single machine, at least 1GB of RAM should be sufficient.
 
 - **Heavy Usage:** Conversely, for heavy GUI interactions and connections to 100+ devices on a single machine, we recommend allocating at least 4GB of RAM to ensure optimal performance.

--- a/_includes/templates/edge/install/linux-configure-edge.md
+++ b/_includes/templates/edge/install/linux-configure-edge.md
@@ -6,19 +6,19 @@
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
-Edit ThingsBoard Edge configuration file 
+Edit the **ThingsBoard Edge** configuration file:
 ```bash 
 sudo nano /etc/tb-edge/conf/tb-edge.conf
 ``` 
 {: .copy-code}
 
-Please update the following lines in your configuration file. Make sure **to replace**:
- * "PUT_YOUR_POSTGRESQL_PASSWORD_HERE" with your **actual postgres user password**.
- * "PUT_YOUR_CLOUD_IP" with an IP address of the machine where **{{appPrefix}}** Server is running. Depending on your setup:
+Update the following lines in your configuration file. Be sure **to replace**:
+ * **"PUT_YOUR_POSTGRESQL_PASSWORD_HERE"** replace with your **actual postgres user password**.
+ * **"PUT_YOUR_CLOUD_IP"** replace with an IP address of the machine running **{{appPrefix}}** Server. This depends on your setup:
    {% if docsPrefix == 'pe/edge/' %}
     * If you're connecting the Edge to [**ThingsBoard Cloud**](https://thingsboard.cloud/signup), use **thingsboard.cloud**.
 
-    **NOTE**: **thingsboard.cloud** employs the SSL protocol for Edge communication. 
+    **NOTE**: **thingsboard.cloud** uses the SSL protocol for communication with the Edge. 
     You should also uncomment **export CLOUD_RPC_SSL_ENABLED=true** in this case.
    {% else %}
     * If you're connecting the Edge to the [**ThingsBoard Live Demo**](https://demo.thingsboard.io/signup) for evaluation, use **demo.thingsboard.io**.
@@ -26,7 +26,7 @@ Please update the following lines in your configuration file. Make sure **to rep
     * Use **localhost** if the Edge is running on the same machine as the Server instance. 
     * Use an **X.X.X.X** IP address if the Edge is connecting to the Server instance in the same network or in a Docker container.
 
- * Replace "PUT_YOUR_EDGE_KEY_HERE" and "PUT_YOUR_EDGE_SECRET_HERE" with the respective **Edge key and secret**:
+ * Replace **"PUT_YOUR_EDGE_KEY_HERE"** and **"PUT_YOUR_EDGE_SECRET_HERE"** with the appropriate **Edge key and secret**:
 
 ```bash
 # UNCOMMENT NEXT LINES AND PUT YOUR CLOUD CONNECTION SETTINGS:
@@ -36,19 +36,29 @@ Please update the following lines in your configuration file. Make sure **to rep
 # UNCOMMENT NEXT LINES IF EDGE CONNECTS TO PE 'THINGSBOARD.CLOUD' SERVER:
 # export CLOUD_RPC_HOST=thingsboard.cloud
 # export CLOUD_RPC_SSL_ENABLED=true
-{% else %}
-# UNCOMMENT NEXT LINES IF EDGE CONNECTS TO CE 'DEMO.THINGSBOARD.IO' SERVER:
-# export CLOUD_RPC_HOST=demo.thingsboard.io
-{% endif %}
-# UNCOMMENT NEXT LINES IF YOU CHANGED DEFAULT CLOUD RPC HOST/PORT SETTINGS:
-# export CLOUD_RPC_HOST=PUT_YOUR_CLOUD_IP
-# export CLOUD_RPC_PORT=7070
 
 # UNCOMMENT NEXT LINES IF YOU ARE RUNNING EDGE ON THE SAME MACHINE WHERE THINGSBOARD SERVER IS RUNNING:
 # export HTTP_BIND_PORT=18080
 # export MQTT_BIND_PORT=11883
 # export COAP_BIND_PORT=15683
 # export LWM2M_ENABLED=false
+# export SNMP_ENABLED=false
+# export INTEGRATIONS_RPC_PORT=19090
+{% else %}
+# UNCOMMENT NEXT LINES IF EDGE CONNECTS TO CE 'DEMO.THINGSBOARD.IO' SERVER:
+# export CLOUD_RPC_HOST=demo.thingsboard.io
+
+# UNCOMMENT NEXT LINES IF YOU ARE RUNNING EDGE ON THE SAME MACHINE WHERE THINGSBOARD SERVER IS RUNNING:
+# export HTTP_BIND_PORT=18080
+# export MQTT_BIND_PORT=11883
+# export COAP_BIND_PORT=15683
+# export LWM2M_ENABLED=false
+# export SNMP_ENABLED=false
+{% endif %}
+# UNCOMMENT NEXT LINES IF YOU CHANGED DEFAULT CLOUD RPC HOST/PORT SETTINGS:
+# export CLOUD_RPC_HOST=PUT_YOUR_CLOUD_IP
+# export CLOUD_RPC_PORT=7070
+
 {% if docsPrefix == 'pe/edge/' %}
 # export INTEGRATIONS_RPC_PORT=19090
 {% endif %}
@@ -59,35 +69,10 @@ Please update the following lines in your configuration file. Make sure **to rep
 ```
 
 {% capture local-deployment %}
-If ThingsBoard Edge is going to be running on the same machine where **{{appPrefix}}** server is running, you'll need to update configuration parameters to avoid port collision between ThingsBoard Server and ThingsBoard Edge.
+To run **ThingsBoard Edge** on the same machine as the **{{appPrefix}}** Server, update the configuration parameters to avoid port collision between them.
+**Uncomment the corresponding lines** in the **tb-edge.conf** file. 
 
-Please execute the following command to update ThingsBoard Edge configuration file (**/etc/tb-edge/conf/tb-edge.conf**):
+Ensure that other applications do not use the **18080, 11883, and 15683** ports.
 {% endcapture %}
 {% include templates/info-banner.md content=local-deployment %}
 
-{% if docsPrefix == 'pe/edge/' %}
-```bash
-sudo sh -c 'cat <<EOL >> /etc/tb-edge/conf/tb-edge.conf
-export HTTP_BIND_PORT=18080
-export MQTT_BIND_PORT=11883
-export COAP_BIND_PORT=15683
-export LWM2M_ENABLED=false
-export SNMP_ENABLED=false
-export INTEGRATIONS_RPC_PORT=19090
-EOL'
-```
-{: .copy-code}
-{% else %}
-```bash
-sudo sh -c 'cat <<EOL >> /etc/tb-edge/conf/tb-edge.conf
-export HTTP_BIND_PORT=18080
-export MQTT_BIND_PORT=11883
-export COAP_BIND_PORT=15683
-export LWM2M_ENABLED=false
-export SNMP_ENABLED=false
-EOL'
-```
-{: .copy-code}
-{% endif %}
-
-Make sure that ports above (18080, 11883, 15683) are not used by any other application.

--- a/_includes/templates/edge/install/manual-install-instructions-intro.md
+++ b/_includes/templates/edge/install/manual-install-instructions-intro.md
@@ -1,4 +1,4 @@
 ## Manual Installation and Configuration
 
-If, for any reason, you are unable to use the prepared **ThingsBoard Server Instructions** above, please follow the steps outlined below.
-These steps will guide you through installing and configuring the Edge by yourself.
+If for any reason you are unable to use the prepared **ThingsBoard Server Instructions** above, please follow the steps below.
+These steps will guide you through installing and configuring the **Edge** by yourself.

--- a/_includes/templates/edge/install/manual-install-instructions-intro.md
+++ b/_includes/templates/edge/install/manual-install-instructions-intro.md
@@ -1,4 +1,4 @@
 ## Manual Installation and Configuration
 
-If, for any reason, you are unable to use the prepared ThingsBoard Server Instructions above, please follow the generic steps outlined below.
+If, for any reason, you are unable to use the prepared **ThingsBoard Server Instructions** above, please follow the steps outlined below.
 These steps will guide you through installing and configuring the Edge by yourself.

--- a/_includes/templates/edge/install/open-edge-ui.md
+++ b/_includes/templates/edge/install/open-edge-ui.md
@@ -4,8 +4,8 @@
 {% assign cloudLink = "[**ThingsBoard Live Demo**](https://demo.thingsboard.io/signup)" %}
 {% endif %}
 
-Once started, you will be able to open **ThingsBoard Edge UI** using the following link `http://localhost:8080`.
+Once the **Edge** service is started, open the **Edge UI** at [http://localhost:8080](http://localhost:8080){: target="_blank"}.
 
 {% include templates/edge/bind-port-changed-banner.md %}
 
-Please use your tenant credentials from local Server instance or {{cloudLink}} to log in to the ThingsBoard Edge.
+Please use your tenant credentials from local Server instance or {{cloudLink}}{: target="_blank"} to log in to the **ThingsBoard Edge**.

--- a/_includes/templates/edge/install/pe-docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/pe-docker-queue-hybrid.md
@@ -16,7 +16,7 @@ version: '3.8'
 services:
   mytbedge:
     restart: always
-    image: "thingsboard/tb-edge:{{ site.release.pe_edge_full_ver }}"
+    image: "thingsboard/tb-edge-pe:{{ site.release.pe_edge_full_ver }}"
     ports:
       - "8080:8080"
       - "1883:1883"
@@ -30,9 +30,9 @@ services:
       TB_KAFKA_SERVERS: "kafka:9092"
       DATABASE_TS_TYPE: "cassandra"
       CASSANDRA_URL: "cassandra:9042"
-    volumes:
-      - tb-edge-data:/data
-      - tb-edge-logs:/var/log/tb-edge
+      volumes:
+        - tb-edge-data:/data
+        - tb-edge-logs:/var/log/tb-edge
   postgres:
     restart: always
     image: "postgres:15"
@@ -68,11 +68,18 @@ services:
       - kafka-data:/bitnami
   cassandra:
     restart: always
-    image: "cassandra:4.1"
+    image: cassandra:4.0
+    container_name: cassandra
+    environment:
+      CASSANDRA_CLUSTER_NAME: "Thingsboard Edge Cluster"
+      CASSANDRA_KEYSPACE_NAME: "tb_edge"
+      CASSANDRA_LOCAL_DATACENTER: "datacenter1"
     ports:
-      - "9042"
+      - 9042:9042
     volumes:
-      - tb-edge-cassandra-data:/var/lib/cassandra
+      - ./data/cassandra:/var/lib/cassandra
+    networks:
+      - cassandra-network
 volumes:
   tb-edge-data:
     name: tb-edge-data
@@ -82,6 +89,9 @@ volumes:
     name: tb-edge-postgres-data
   kafka-data:
     driver: local
+networks:
+  cassandra-network:
+    driver: bridge
 ```
 {: .copy-code}
 

--- a/_includes/templates/edge/install/pe-docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/pe-docker-queue-hybrid.md
@@ -16,7 +16,7 @@ version: '3.8'
 services:
   mytbedge:
     restart: always
-    image: "thingsboard/tb-edge:3.9.0EDGE"
+    image: "thingsboard/tb-edge:{{ site.release.pe_edge_full_ver }}"
     ports:
       - "8080:8080"
       - "1883:1883"

--- a/_includes/templates/edge/install/pe-docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/pe-docker-queue-hybrid.md
@@ -1,3 +1,5 @@
+[Apache Cassandra](https://cassandra.apache.org/_/index.html){: target="_blank"} is an open source NoSQL database designed to manage massive amounts of data.
+
 [Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
 Create docker compose file for the **ThingsBoard Edge** service:
@@ -26,6 +28,8 @@ services:
       CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
       TB_QUEUE_TYPE: "kafka"
       TB_KAFKA_SERVERS: "kafka:9092"
+      DATABASE_TS_TYPE: "cassandra"
+      CASSANDRA_URL: "cassandra:9042"
     volumes:
       - tb-edge-data:/data
       - tb-edge-logs:/var/log/tb-edge
@@ -62,6 +66,13 @@ services:
       KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093" #KRaft
     volumes:
       - kafka-data:/bitnami
+  cassandra:
+    restart: always
+    image: "cassandra:4.1"
+    ports:
+      - "9042"
+    volumes:
+      - tb-edge-cassandra-data:/var/lib/cassandra
 volumes:
   tb-edge-data:
     name: tb-edge-data

--- a/_includes/templates/edge/install/pe-docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/pe-docker-queue-hybrid.md
@@ -23,9 +23,11 @@ services:
       - "5683-5688:5683-5688/udp"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+      EDGE_LICENSE_INSTANCE_DATA_FILE: /data/instance-edge-license.data
       CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
       CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
       CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
+      CLOUD_RPC_SSL_ENABLED: 'false' # set it to 'true' if you are connecting edge to thingsboard.cloud
       TB_QUEUE_TYPE: "kafka"
       TB_KAFKA_SERVERS: "kafka:9092"
       DATABASE_TS_TYPE: "cassandra"
@@ -33,6 +35,8 @@ services:
       volumes:
         - tb-edge-data:/data
         - tb-edge-logs:/var/log/tb-edge
+      extra_hosts:
+        - "host.docker.internal:host-gateway"
   postgres:
     restart: always
     image: "postgres:15"

--- a/_includes/templates/edge/install/pe-docker-queue-kafka.md
+++ b/_includes/templates/edge/install/pe-docker-queue-kafka.md
@@ -15,7 +15,7 @@ version: '3.8'
 services:
   mytbedge:
     restart: always
-    image: "thingsboard/tb-edge-pe:3.9.0EDGEPE"
+    image: "thingsboard/tb-edge-pe:{{ site.release.pe_edge_full_ver }}"
     ports:
       - "8080:8080"
       - "1883:1883"

--- a/_includes/templates/edge/install/pe-docker-queue-kafka.md
+++ b/_includes/templates/edge/install/pe-docker-queue-kafka.md
@@ -1,5 +1,5 @@
 
-[Apache Kafka](https://kafka.apache.org/) is an open-source stream-processing software platform.
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
 Create docker compose file for the **ThingsBoard Edge** service:
 

--- a/_includes/templates/edge/install/pe-docker-queue-kafka.md
+++ b/_includes/templates/edge/install/pe-docker-queue-kafka.md
@@ -1,0 +1,84 @@
+
+[Apache Kafka](https://kafka.apache.org/) is an open-source stream-processing software platform.
+
+Create docker compose file for the **ThingsBoard Edge** service:
+
+```text
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following lines to the **docker-compose.yml** file:
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: always
+    image: "thingsboard/tb-edge-pe:3.9.0EDGEPE"
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "5683-5688:5683-5688/udp"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+      EDGE_LICENSE_INSTANCE_DATA_FILE: /data/instance-edge-license.data
+      CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
+      CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
+      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. host.docker.internal, 192.168.1.1 or thingsboard.cloud, etc.
+      CLOUD_RPC_SSL_ENABLED: 'false' # set it to 'true' if you are connecting edge to thingsboard.cloud
+      TB_QUEUE_TYPE: "kafka"
+      TB_KAFKA_SERVERS: "kafka:9092"
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+    extra_hosts:
+      - "host.docker.internal:host-gateway" 
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_DB: tb-edge
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - tb-edge-postgres-data:/var/lib/postgresql/data
+  kafka:
+    restart: always
+    image: bitnami/kafka:3.8.1
+    ports:
+      - 9092:9092 #to localhost:9092 from host machine
+      - 9093 #for Kraft
+      - 9094 #to kafka:9094 from within Docker network
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_LISTENERS: "OUTSIDE://:9092,CONTROLLER://:9093,INSIDE://:9094"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "OUTSIDE://localhost:9092,INSIDE://kafka:9094"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "INSIDE"
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker" #KRaft
+      KAFKA_CFG_NODE_ID: "0" #KRaft
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER" #KRaft
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093" #KRaft
+    volumes:
+      - kafka-data:/bitnami
+volumes:
+  tb-edge-data:
+    name: tb-edge-data
+  tb-edge-logs:
+    name: tb-edge-logs
+  tb-edge-postgres-data:
+    name: tb-edge-postgres-data
+  kafka-data:
+    driver: local
+```
+{: .copy-code}
+
+{% include templates/edge/install/docker_compose_details_explain.md %}
+
+{% include templates/install/docker/docker-compose-up.md %}

--- a/_includes/templates/edge/install/postgres-install-rhel.md
+++ b/_includes/templates/edge/install/postgres-install-rhel.md
@@ -1,0 +1,41 @@
+To install **PostgreSQL**, follow the instructions below.
+
+```bash
+# Update your system
+sudo dnf update
+```
+{: .copy-code}
+
+Install the repository:
+
+* **For CentOS/RHEL 8:**
+
+```bash
+# Install the repository RPM:
+sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+```
+{: .copy-code}
+
+* **For CentOS/RHEL 9:**
+
+```bash
+# Install the repository RPM:
+sudo dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+```
+{: .copy-code}
+
+Install the package.
+
+```bash
+# Install packages
+sudo dnf -qy module disable postgresql
+sudo dnf -y install postgresql16 postgresql16-server postgresql16-contrib
+# Initialize your PostgreSQL DB
+sudo /usr/pgsql-16/bin/postgresql-16-setup initdb
+sudo systemctl start postgresql-16
+# Optional: Configure PostgreSQL to start on boot
+sudo systemctl enable --now postgresql-16
+```
+{: .copy-code}
+
+{% include templates/install/postgres-post-install.md %}

--- a/_includes/templates/edge/install/prerequisites.md
+++ b/_includes/templates/edge/install/prerequisites.md
@@ -1,6 +1,6 @@
 ## Prerequisites
 
-To start utilizing the ThingsBoard **Edge**, it is essential to have an operational ThingsBoard {{appPrefix}} server that supports Edge functionality.
+To start using the **ThingsBoard Edge**, it is essential to have a running **ThingsBoard {{appPrefix}} server** that supports Edge functionality.
 
 {% if docsPrefix == 'pe/edge/' %}
 {% include templates/edge/obtain-pe-cloud.md %}
@@ -18,10 +18,10 @@ Additionally, you will need to provision **Edge** on the ThingsBoard server.
 {% assign addEdge = '
     ===
         image: /images/pe/edge/installation-add-edge-item-1.png,
-        title: Sign in to your ThingsBoard PE instance and navigate to the "Edge Management" section -> "Instances" page. Click the "+" icon in the top right corner and select "Add new edge".
+        title: Log in to your **ThingsBoard PE** instance and navigate to the **Edge Management -> Instances** section. Click the **"+"** icon in the top right corner and select **"Add new edge"**.
     ===
         image: /images/pe/edge/installation-add-edge-item-2.png,
-        title: Enter a name for your edge. For instance, "My New Edge". If necessary, update the cloud endpoint. This URL should be accessible from the edge. If the edge is running in a Docker container, using "localhost" is <b>incorrect</b>. It must be the IP address of the machine where ThingsBoard <b>PE</b> is running and accessible by the edge container. If you are using the ThingsBoard <b>Cloud</b> server to evaluate the edge, leave this setting as it is. Click "Add" to confirm adding your new Edge.
+        title: Enter a name for your edge. For instance, "My New Edge". If necessary, update the cloud endpoint. This URL should be accessible from the edge. **If the Edge is running in a Docker container, using "localhost" is incorrect**. It must be the **IP address** of the machine running **ThingsBoard PE** that is accessible from the edge container. If you are using the **ThingsBoard Cloud** server to evaluate the edge, leave this setting as it is. Click **"Add"** to confirm the addition of your new Edge.
     ===
         image: /images/pe/edge/installation-add-edge-item-3.png,
         title: Your new edge should now appear at the top of the list, as entries are sorted by creation time by default.
@@ -30,10 +30,10 @@ Additionally, you will need to provision **Edge** on the ThingsBoard server.
 {% assign addEdge = '
     ===
         image: /images/edge/installation-add-edge-item-1.png,
-        title: Sign in to your ThingsBoard instance and navigate to the "Edge Management" section -> "Instances" page. Click the "+" icon in the top right corner and select "Add new edge".
+        title: Log in to your **ThingsBoard PE** instance and navigate to the **Edge Management -> Instances** section. Click the **"+"** icon in the top right corner and select **"Add new edge"**.
     ===
         image: /images/edge/installation-add-edge-item-2.png,
-        title: Enter a name for your Edge. For instance, "My New Edge". Click "Add" to confirm adding of your new Edge.
+        title: Enter a name for your Edge. For instance, "My New Edge". Click **"Add"** to confirm the addition of your new Edge.
     ===
         image: /images/edge/installation-add-edge-item-3.png,
         title: Your new Edge should now appear at the top of the list, as entries are sorted by creation time by default.

--- a/_includes/templates/edge/install/queue-kafka-in-docker.md
+++ b/_includes/templates/edge/install/queue-kafka-in-docker.md
@@ -1,0 +1,49 @@
+#### Kafka Installation
+
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open-source stream-processing platform.
+
+To install **Kafka in a [Docker](https://docs.docker.com/engine/install/){: target="_blank"}** container, follow the instructions below:
+
+```text
+nano docker-compose-kafka.yml
+```
+{: .copy-code}
+
+Add the following lines to the **docker-compose-kafka.yml** file:
+```yml
+version: '3.8'
+services:
+  kafka:
+    restart: always
+    image: bitnami/kafka:3.8.1
+    ports:
+      - 9092:9092 #to localhost:9092 from host machine
+      - 9093 #for Kraft
+      - 9094 #to kafka:9094 from within Docker network
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_LISTENERS: "OUTSIDE://:9092,CONTROLLER://:9093,INSIDE://:9094"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "OUTSIDE://localhost:9092,INSIDE://kafka:9094"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT,CONTROLLER:PLAINTEXT"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "INSIDE"
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker" #KRaft
+      KAFKA_CFG_NODE_ID: "0" #KRaft
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER" #KRaft
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093" #KRaft
+    volumes:
+      - kafka-data:/bitnami
+volumes:
+  kafka-data:
+    driver: local
+```
+{: .copy-code}
+
+Start the container:
+```text
+docker compose -f docker-compose-kafka.yml up -d
+```
+{: .copy-code}

--- a/_includes/templates/edge/install/queue-kafka-in-docker.md
+++ b/_includes/templates/edge/install/queue-kafka-in-docker.md
@@ -1,6 +1,6 @@
 #### Kafka Installation
 
-[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open-source stream-processing platform.
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing platform.
 
 To install **Kafka in a [Docker](https://docs.docker.com/engine/install/){: target="_blank"}** container, follow the instructions below:
 

--- a/_includes/templates/edge/install/rhel-db-hybrid.md
+++ b/_includes/templates/edge/install/rhel-db-hybrid.md
@@ -1,0 +1,47 @@
+{% capture hybrid-info %}
+The ThingsBoard team recommends using a **hybrid database approach** if you plan to manage 1M+ devices in production or handle **high data ingestion rate (grater than 5000 msg/sec)**. 
+In this case, **ThingsBoard Edge** stores time-series data in Cassandra while continuing to use PostgreSQL for primary entities such as devices, assets, dashboards, and customers.
+{% endcapture %}
+{% include templates/info-banner.md content=hybrid-info %}
+
+##### PostgreSQL Installation
+
+{% include templates/edge/install/postgres-install-rhel.md %}
+
+{% include templates/edge/create-tb-db-rhel.md %}
+
+##### Cassandra Installation
+
+{% include templates/edge/install/cassandra-rhel-install.md %}
+
+##### ThingsBoard Edge Configuration
+
+Edit **ThingsBoard Edge** configuration file: 
+
+```bash 
+sudo nano /etc/tb-edge/conf/tb-edge.conf
+``` 
+{: .copy-code}
+
+Add the following lines to the configuration file. Don't forget **to replace** "PUT_YOUR_POSTGRESQL_PASSWORD_HERE" with your **real postgres user password**:
+
+```bash
+# DB Configuration 
+export DATABASE_TS_TYPE=cassandra
+export SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/tb_edge
+export SPRING_DATASOURCE_USERNAME=postgres
+export SPRING_DATASOURCE_PASSWORD=PUT_YOUR_POSTGRESQL_PASSWORD_HERE
+``` 
+{: .copy-code}
+
+You can optionally add the following parameters to reconfigure your ThingsBoard Edge instance to connect to external Cassandra nodes:
+
+```bash
+export CASSANDRA_CLUSTER_NAME=Edge Cluster
+export CASSANDRA_KEYSPACE_NAME=tb_edge
+export CASSANDRA_URL=127.0.0.1:9043
+export CASSANDRA_USE_CREDENTIALS=false
+export CASSANDRA_USERNAME=
+export CASSANDRA_PASSWORD=
+```
+{: .copy-code}

--- a/_includes/templates/edge/install/rhel-db-hybrid.md
+++ b/_includes/templates/edge/install/rhel-db-hybrid.md
@@ -38,8 +38,8 @@ You can optionally add the following parameters to reconfigure your ThingsBoard 
 
 ```bash
 export CASSANDRA_CLUSTER_NAME=Edge Cluster
-export CASSANDRA_KEYSPACE_NAME=tb_edge
-export CASSANDRA_URL=127.0.0.1:9043
+export CASSANDRA_KEYSPACE_NAME=thingsboard
+export CASSANDRA_URL=127.0.0.1:9042
 export CASSANDRA_USE_CREDENTIALS=false
 export CASSANDRA_USERNAME=
 export CASSANDRA_PASSWORD=

--- a/_includes/templates/edge/install/rhel-db-hybrid.md
+++ b/_includes/templates/edge/install/rhel-db-hybrid.md
@@ -1,5 +1,5 @@
 {% capture hybrid-info %}
-The ThingsBoard team recommends using a **hybrid database approach** if you plan to manage 1M+ devices in production or handle **high data ingestion rate (grater than 5000 msg/sec)**. 
+The ThingsBoard team recommends using a **hybrid database approach** if you plan to manage 1M+ devices in production or handle **high data ingestion rate (more than 5000 msg/sec)**. 
 In this case, **ThingsBoard Edge** stores time-series data in Cassandra while continuing to use PostgreSQL for primary entities such as devices, assets, dashboards, and customers.
 {% endcapture %}
 {% include templates/info-banner.md content=hybrid-info %}

--- a/_includes/templates/edge/install/rhel-db-postgresql.md
+++ b/_includes/templates/edge/install/rhel-db-postgresql.md
@@ -1,6 +1,11 @@
+{% capture postgresql-info %}
+The ThingsBoard team recommends using **PostgreSQL** for development and production environments with **moderate load (less than 5000 msg/sec)**.
+Many cloud providers offer managed **PostgreSQL** services, making it a cost-effective solution for most ThingsBoard deployments.
+{% endcapture %}
+{% include templates/info-banner.md content=postgresql-info %}
 
-ThingsBoard Edge uses PostgreSQL database as a local storage.
+ThingsBoard Edge uses **PostgreSQL** database as a local storage.
 
-{% include templates/install/postgres-install-rhel.md %}
+{% include templates/edge/install/postgres-install-rhel.md %}
 
 {% include templates/edge/create-tb-db-rhel.md %}

--- a/_includes/templates/edge/install/rhel-queue-kafka.md
+++ b/_includes/templates/edge/install/rhel-queue-kafka.md
@@ -1,0 +1,17 @@
+{% include templates/edge/install/queue-kafka-in-docker.md %}
+
+##### ThingsBoard Edge Configuration
+
+Edit **ThingsBoard Edge** configuration file:
+
+```bash 
+sudo nano /etc/tb-edge/conf/tb-edge.conf
+``` 
+{: .copy-code}
+
+Add the following line to the configuration file. Replace "localhost:9092" with **your real Kafka bootstrap servers** if needed:
+
+```bash
+export TB_QUEUE_TYPE=kafka
+export TB_KAFKA_SERVERS=localhost:9092
+```

--- a/_includes/templates/edge/install/run-edge-install.md
+++ b/_includes/templates/edge/install/run-edge-install.md
@@ -1,7 +1,13 @@
 
-Once ThingsBoard Edge is installed and configured please execute the following install script:
+Once **ThingsBoard Edge** is installed and configured please execute the following installation script:
 
 ```bash
 sudo /usr/share/tb-edge/bin/install/install.sh
 ```
 {: .copy-code}
+
+{% capture local-deployment %}
+Make sure you run this script from the root. To change the current directory to the root directory, run the command **cd /**.
+{% endcapture %}
+{% include templates/info-banner.md content=local-deployment %}
+

--- a/_includes/templates/edge/install/tb-server-pre-configured-install-instructions.md
+++ b/_includes/templates/edge/install/tb-server-pre-configured-install-instructions.md
@@ -1,5 +1,6 @@
-The most straightforward method to install and connect Edge to the Server is by utilizing the prepared installation instructions provided by the ThingsBoard Server.
-For every Edge Entity, the Server has prepared instructions with already populated fields such as the Edge secret key, Edge routing key, Edge RPC host URI, etc.
+The easiest way to install and connect the **Edge** to the Server is to follow the installation instructions provided by the **ThingsBoard Server**.
+For every **Edge Entity**,  the Server displays the instructions with **pre-populated field**s such as the Edge secret key, Edge routing key, Edge RPC host URI, and so on
+
 Please follow the steps below to use these prepared instructions:
 
 
@@ -8,13 +9,13 @@ Please follow the steps below to use these prepared instructions:
 {% assign preparedInstructionsInstall = '
     ===
         image: /images/pe/edge/installation/prepared-instructions-install-item-1-pe.png,
-        title: Click an Edge entity row to open it&#39;s details;
+        title: Click an **Edge entity row** to open its details;
     ===
         image: /images/pe/edge/installation/prepared-instructions-install-item-2-pe.png,
-        title: Click on the "Install & Connection Instructions" button;
+        title: Click on the **"Install & Connect Instructions"** button;
     ===
         image: /images/pe/edge/installation/prepared-instructions-install-item-3-pe.png,
-        title: Follow instructions to install Edge and connect to the server.
+        title: Follow the instructions to install **Edge** and connect to the server.
 '%}
 
 {% else %}
@@ -22,13 +23,13 @@ Please follow the steps below to use these prepared instructions:
 {% assign preparedInstructionsInstall = '
     ===
         image: /images/edge/installation/prepared-instructions-install-item-1-ce.png,
-        title: Click an Edge entity row to open it&#39;s details;
+        title: Click an **Edge entity row** to open its details;
     ===
         image: /images/edge/installation/prepared-instructions-install-item-2-ce.png,
-        title: Click on the "Install & Connection Instructions" button;
+        title: Click on the **"Install & Connect Instructions"** button;
     ===
         image: /images/edge/installation/prepared-instructions-install-item-3-ce.png,
-        title: Follow instructions to install Edge and connect to the server.
+        title: Follow the instructions to install **Edge** and connect to the server.
 '%}
 
 {% endif %}

--- a/_includes/templates/edge/install/ubuntu-db-hybrid.md
+++ b/_includes/templates/edge/install/ubuntu-db-hybrid.md
@@ -1,5 +1,5 @@
 {% capture hybrid-info %}
-The ThingsBoard team recommends using a **hybrid database approach** if you plan to manage 1M+ devices in production or handle **high data ingestion rate (grater than 5000 msg/sec)**.
+The ThingsBoard team recommends using a **hybrid database approach** if you plan to manage 1M+ devices in production or handle **high data ingestion rate (more than 5000 msg/sec)**.
 In this case, **ThingsBoard Edge** stores time-series data in Cassandra while continuing to use PostgreSQL for primary entities such as devices, assets, dashboards, and customers.  
 {% endcapture %}
 {% include templates/info-banner.md content=hybrid-info %}

--- a/_includes/templates/edge/install/ubuntu-db-hybrid.md
+++ b/_includes/templates/edge/install/ubuntu-db-hybrid.md
@@ -51,8 +51,8 @@ You can optionally add the following parameters to reconfigure your Edge instanc
 
 ```bash
 export CASSANDRA_CLUSTER_NAME=Edge Cluster
-export CASSANDRA_KEYSPACE_NAME=tb_edge
-export CASSANDRA_URL=127.0.0.1:9043
+export CASSANDRA_KEYSPACE_NAME=thingsboard
+export CASSANDRA_URL=127.0.0.1:9042
 export CASSANDRA_USE_CREDENTIALS=false
 export CASSANDRA_USERNAME=
 export CASSANDRA_PASSWORD=

--- a/_includes/templates/edge/install/ubuntu-db-hybrid.md
+++ b/_includes/templates/edge/install/ubuntu-db-hybrid.md
@@ -1,0 +1,60 @@
+{% capture hybrid-info %}
+The ThingsBoard team recommends using a **hybrid database approach** if you plan to manage 1M+ devices in production or handle **high data ingestion rate (grater than 5000 msg/sec)**.
+In this case, **ThingsBoard Edge** stores time-series data in Cassandra while continuing to use PostgreSQL for primary entities such as devices, assets, dashboards, and customers.  
+{% endcapture %}
+{% include templates/info-banner.md content=hybrid-info %}
+
+##### PostgreSQL Installation
+
+{% include templates/install/postgres-install-ubuntu.md %}
+
+Connect to the **"postgres"** database as the **"postgres"** user:
+
+```bash
+psql -U postgres -d postgres -h 127.0.0.1 -W
+```
+{: .copy-code}
+
+Create the **ThingsBoard Edge** database and name it **"tb_edge"** :
+```bash
+CREATE DATABASE tb_edge;
+```
+{: .copy-code}
+
+Press **"Ctrl+D"** twice to quit PostgreSQL.
+
+##### Cassandra Installation
+
+{% include templates/edge/install/cassandra-ubuntu-install.md %}
+
+##### ThingsBoard Edge Configuration
+
+Edit **ThingsBoard Edge** configuration file:
+
+```bash 
+sudo nano /etc/tb-edge/conf/tb-edge.conf
+``` 
+{: .copy-code}
+
+Add the following lines to the configuration file. Don't forget **to replace** "PUT_YOUR_POSTGRESQL_PASSWORD_HERE" with your **real postgres user password**:
+
+```bash
+# DB Configuration 
+export DATABASE_TS_TYPE=cassandra
+export SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/tb_edge
+export SPRING_DATASOURCE_USERNAME=postgres
+export SPRING_DATASOURCE_PASSWORD=PUT_YOUR_POSTGRESQL_PASSWORD_HERE
+``` 
+{: .copy-code}
+
+You can optionally add the following parameters to reconfigure your Edge instance to connect to external Cassandra nodes:
+
+```bash
+export CASSANDRA_CLUSTER_NAME=Edge Cluster
+export CASSANDRA_KEYSPACE_NAME=tb_edge
+export CASSANDRA_URL=127.0.0.1:9043
+export CASSANDRA_USE_CREDENTIALS=false
+export CASSANDRA_USERNAME=
+export CASSANDRA_PASSWORD=
+```
+{: .copy-code}

--- a/_includes/templates/edge/install/ubuntu-db-postgresql.md
+++ b/_includes/templates/edge/install/ubuntu-db-postgresql.md
@@ -1,6 +1,6 @@
 {% capture postgresql-info %}
-ThingsBoard team recommends to use PostgreSQL for development and production environments with reasonable load (< 5000 msg/sec).
-Many cloud vendors support managed PostgreSQL servers which is a cost-effective solution for most of ThingsBoard instances.
+The ThingsBoard team recommends using **PostgreSQL** for development and production environments with **moderate load (less than 5000 msg/sec)**.
+Many cloud providers offer managed **PostgreSQL** services, making it a cost-effective solution for most ThingsBoard deployments.
 {% endcapture %}
 {% include templates/info-banner.md content=postgresql-info %}
 
@@ -8,17 +8,17 @@ Many cloud vendors support managed PostgreSQL servers which is a cost-effective 
 
 {% include templates/install/postgres-install-ubuntu.md %}
 
-Then, connect to the "postgres" database as the "postgres" user:
+Connect to the **"postgres"** database as the **"postgres"** user:
 
 ```bash
 psql -U postgres -d postgres -h 127.0.0.1 -W
 ```
 {: .copy-code}
 
-Create the ThingsBoard Edge database named "tb_edge" :
+Create the **ThingsBoard Edge** database and name it **"tb_edge"** :
 ```bash
 CREATE DATABASE tb_edge;
 ```
 {: .copy-code}
 
-Press "Ctrl+D" twice to exit PostgreSQL.
+Press **"Ctrl+D"** twice to quit PostgreSQL.

--- a/_includes/templates/edge/install/ubuntu-db-postgresql.md
+++ b/_includes/templates/edge/install/ubuntu-db-postgresql.md
@@ -1,5 +1,10 @@
+{% capture postgresql-info %}
+ThingsBoard team recommends to use PostgreSQL for development and production environments with reasonable load (< 5000 msg/sec).
+Many cloud vendors support managed PostgreSQL servers which is a cost-effective solution for most of ThingsBoard instances.
+{% endcapture %}
+{% include templates/info-banner.md content=postgresql-info %}
 
-ThingsBoard Edge uses PostgreSQL database as a local storage.
+**ThingsBoard Edge** uses **PostgreSQL** database as a local storage.
 
 {% include templates/install/postgres-install-ubuntu.md %}
 

--- a/_includes/templates/edge/install/ubuntu-queue-kafka-in-docker.md
+++ b/_includes/templates/edge/install/ubuntu-queue-kafka-in-docker.md
@@ -1,0 +1,17 @@
+{% include templates/edge/install/queue-kafka-in-docker.md %}
+
+##### ThingsBoard Edge Configuration
+
+Edit **ThingsBoard Edge** configuration file:
+
+```bash 
+sudo nano /etc/tb-edge/conf/tb-edge.conf
+``` 
+{: .copy-code}
+
+Add the following line to the configuration file. Replace "localhost:9092" with **your real Kafka bootstrap servers** if needed:
+
+```bash
+export TB_QUEUE_TYPE=kafka
+export TB_KAFKA_SERVERS=localhost:9092
+```

--- a/_includes/templates/edge/install/ubuntu-queue-kafka.md
+++ b/_includes/templates/edge/install/ubuntu-queue-kafka.md
@@ -1,0 +1,112 @@
+#### Kafka Installation
+
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open-source stream-processing platform.
+
+{% capture local-deployment %}
+**Kafka** can be run on either **ThingsBoard Server** or **ThingsBoard Edge**. However, it is **not possible to run Kafka on both** services simultaneously, as this would create conflicts or inefficiencies.
+{% endcapture %}
+{% include templates/info-banner.md content=local-deployment %}
+
+##### Install ZooKeeper
+
+Kafka uses [ZooKeeper](https://zookeeper.apache.org/){: target="_blank"} so you need to first install ZooKeeper server:
+
+```text
+sudo apt-get install zookeeper
+```
+{: .copy-code}
+
+##### Setup ZooKeeper Systemd Unit file
+
+Create systemd unit file for Zookeeper:
+```text
+sudo nano /etc/systemd/system/zookeeper.service
+```
+{: .copy-code}
+
+Add below content:
+```bash
+[Unit]
+Description=Apache Zookeeper server
+Documentation=http://zookeeper.apache.org
+Requires=network.target remote-fs.target
+After=network.target remote-fs.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/kafka/bin/zookeeper-server-start.sh /usr/local/kafka/config/zookeeper.properties
+ExecStop=/usr/local/kafka/bin/zookeeper-server-stop.sh
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target
+```
+{: .copy-code}
+
+##### Enable and start ZooKeeper:
+
+```text
+sudo systemctl enable --now zookeeper
+```
+{: .copy-code}
+
+##### Install Kafka
+
+```text
+wget https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz
+
+tar -xzf kafka_2.13-3.8.1.tgz
+
+sudo mv kafka_2.13-3.8.1 /usr/local/kafka
+```
+{: .copy-code}
+
+##### Setup Kafka Systemd Unit file
+
+Create systemd unit file for Kafka:
+```text
+sudo nano /etc/systemd/system/kafka.service
+```
+{: .copy-code}
+
+Add the below content. Make sure **to replace** "PUT_YOUR_JAVA_PATH" with your **real JAVA_HOME path** as per the Java installed on your system, by default like "/usr/lib/jvm/java-11-openjdk-xxx":
+```bash
+[Unit]
+Description=Apache Kafka Server
+Documentation=http://kafka.apache.org/documentation.html
+Requires=zookeeper.service
+
+[Service]
+Type=simple
+Environment="JAVA_HOME=PUT_YOUR_JAVA_PATH"
+ExecStart=/usr/local/kafka/bin/kafka-server-start.sh /usr/local/kafka/config/server.properties
+ExecStop=/usr/local/kafka/bin/kafka-server-stop.sh
+
+[Install]
+WantedBy=multi-user.target
+```
+{: .copy-code}
+
+##### Enable and start Kafka:
+
+```text
+sudo systemctl enable --now kafka
+```
+{: .copy-code}
+
+##### ThingsBoard Configuration
+
+Edit the **ThingsBoard Edge** configuration file:
+
+```text
+sudo nano /etc/tb-edge/conf/tb-edge.conf
+```
+{: .copy-code}
+
+Add the following line to the **tb-edge.conf** file. **Make sure** to replace "localhost:9092" with your real Kafka bootstrap servers if necessary:
+
+```bash
+export TB_QUEUE_TYPE=kafka
+export TB_KAFKA_SERVERS=localhost:9092
+```
+{: .copy-code}

--- a/_includes/templates/edge/install/ubuntu-queue-kafka.md
+++ b/_includes/templates/edge/install/ubuntu-queue-kafka.md
@@ -1,6 +1,6 @@
 #### Kafka Installation
 
-[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open-source stream-processing platform.
+[Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing platform.
 
 {% capture local-deployment %}
 **Kafka** can be run on either **ThingsBoard Server** or **ThingsBoard Edge**. However, it is **not possible to run Kafka on both** services simultaneously, as this would create conflicts or inefficiencies.

--- a/_includes/templates/edge/obtain-ce-cloud.md
+++ b/_includes/templates/edge/obtain-ce-cloud.md
@@ -1,4 +1,4 @@
-The easiest way is to use [Live Demo](https://demo.thingsboard.io/signup){:target="_blank"} server.
+The easiest way is to use the [Live Demo](https://demo.thingsboard.io/signup){:target="_blank"} server.
 
 Alternatively, you can install the ThingsBoard Community Edition server on-premise. 
 For this, please refer to the [ThingsBoard installation](/docs/user-guide/install/installation-options/){:target="_blank"} guide.

--- a/_includes/templates/edge/obtain-pe-cloud.md
+++ b/_includes/templates/edge/obtain-pe-cloud.md
@@ -1,4 +1,4 @@
-The easiest way is to use [ThingsBoard Cloud](https://thingsboard.cloud/signup){:target="_blank"} server.
+The easiest way is to use the [ThingsBoard Cloud](https://thingsboard.cloud/signup){:target="_blank"} server.
 
 Alternatively, you can install the ThingsBoard Professional Edition server on-premise.
 For this, please refer to the [ThingsBoard Professional Edition installation](/docs/user-guide/install/pe/installation-options/){:target="_blank"} guide.

--- a/_includes/templates/edge/pe-docker-queue-in-memory.md
+++ b/_includes/templates/edge/pe-docker-queue-in-memory.md
@@ -1,4 +1,4 @@
-Create docker compose file for ThingsBoard Edge service:
+Create docker compose file for **ThingsBoard Edge** service:
 
 ```text
 nano docker-compose.yml

--- a/_includes/templates/edge/pe-docker-queue-in-memory.md
+++ b/_includes/templates/edge/pe-docker-queue-in-memory.md
@@ -1,0 +1,54 @@
+Create docker compose file for ThingsBoard Edge service:
+
+```text
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following lines to the yml file:
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: always
+    image: "thingsboard/tb-edge-pe:{{ site.release.pe_edge_full_ver }}"
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "5683-5688:5683-5688/udp"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+      EDGE_LICENSE_INSTANCE_DATA_FILE: /data/instance-edge-license.data
+      CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
+      CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
+      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or thingsboard.cloud
+      CLOUD_RPC_SSL_ENABLED: 'false' # set it to 'true' if you are connecting edge to thingsboard.cloud 
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_DB: tb-edge
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - tb-edge-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  tb-edge-data:
+    name: tb-edge-data
+  tb-edge-logs:
+    name: tb-edge-logs
+  tb-edge-postgres-data:
+    name: tb-edge-postgres-data
+```
+{: .copy-code}
+
+{% include templates/edge/install/docker_compose_details_explain.md %}
+
+{% assign serviceName = "tbedge" %}
+{% include templates/install/docker/docker-compose-up.md %}

--- a/_includes/templates/install/postgres-install-ubuntu.md
+++ b/_includes/templates/install/postgres-install-ubuntu.md
@@ -1,4 +1,4 @@
-Instructions listed below will help you to install PostgreSQL.
+The following instructions will help you install **PostgreSQL**:
 
 ```bash
 # Automated repository configuration:

--- a/_includes/templates/install/postgres-post-install.md
+++ b/_includes/templates/install/postgres-post-install.md
@@ -1,5 +1,5 @@
-Once PostgreSQL is installed you may want to create a new user or set the password for the main user. 
-The instructions below will help to set the password for main PostgreSQL user.
+Once **PostgreSQL** is installed, you may want to create a new user or set the password for the main user.
+The following instructions will help you to set the **password** for the main **PostgreSQL** user.
 
 To switch your current user context to the postgres user, execute the following script:
 ```bash
@@ -7,17 +7,17 @@ sudo su - postgres
 ```
 {: .copy-code}
 
-To be able to interact with the PostgreSQL database, enter:
+To interact with the **PostgreSQL** database, enter:
 ```bash
 psql
 ```
 {: .copy-code}
 
-You will connect to the database as the main PostgreSQL user. To set the password, enter the following command after **postgres=#** :
+You will connect to the database as the **main** PostgreSQL user. To set the password, enter the following command after **postgres=#** :
 ```bash
 \password
 ```
 {: .copy-code}
 
 Enter and confirm the password. 
-Then, press "Ctrl+D" to return to main user console. 
+Then, press **"Ctrl+D"** to return to the main user console. 

--- a/_includes/templates/install/queue-in-memory.md
+++ b/_includes/templates/install/queue-in-memory.md
@@ -1,1 +1,1 @@
-In Memory queue is built-in and enabled by default. No additional configuration steps required.
+**In Memory** queue is built in and enabled by default. No additional configuration is required.

--- a/docs/edge/releases.md
+++ b/docs/edge/releases.md
@@ -8,6 +8,14 @@ description: ThingsBoard Edge Release Notes
 * TOC
 {:toc}
 
+## v3.9.0 (Jan 13, 2025) {#v39}
+
+**Major** release with everything from [TB CE v3.9](/docs/reference/releases/#v39):
+
+* [#125](https://github.com/thingsboard/thingsboard-edge/pull/125) Use of Kafka to store and process Cloud Events to improve processing throughput by @jekka001;
+* [#136](https://github.com/thingsboard/thingsboard-edge/pull/136) Access Edge Attributes on edge instance itself @jekka001;
+* Cassandra support as Timeseries storage by @AndriiLandiak;
+
 ## v3.8.0 (Oct 15, 2024) {#v38}
 
 **Major** release with everything from [TB CE v3.8](/docs/reference/releases/#v38):

--- a/docs/pe/edge/releases.md
+++ b/docs/pe/edge/releases.md
@@ -8,6 +8,10 @@ description: ThingsBoard Edge Release Notes
 * TOC
 {:toc}
 
+## v3.9.0 (Jan 13, 2025) {#v39}
+
+**Major** release with everything from [TB Edge v3.9](/docs/edge/releases/#v39) and [TB PE v3.9](/docs/pe/reference/releases/#v39).
+
 ## v3.8.0 (Oct 15, 2024) {#v38}
 
 **Major** release with everything from [TB Edge v3.8](/docs/edge/releases/#v38) and [TB PE v3.8](/docs/pe/reference/releases/#v38).

--- a/docs/user-guide/install/edge/deb-installation.md
+++ b/docs/user-guide/install/edge/deb-installation.md
@@ -42,7 +42,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 * **In Memory**: The built-in and default queue implementation. It is useful for development or proof-of-concept (PoC) environments, but is not recommended for production or any type of clustered deployments due to limited scalability.
 
-* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you want to stay independent of your cloud provider. However, some providers also offer managed services for Kafka. See for example [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"}.
+* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now.
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%

--- a/docs/user-guide/install/edge/deb-installation.md
+++ b/docs/user-guide/install/edge/deb-installation.md
@@ -26,32 +26,34 @@ This guide describes how to install **ThingsBoard Edge** on Ubuntu 18.04 LTS / U
 
 {% include templates/install/ubuntu-java-install.md %}
 
-### Step 2. Configure ThingsBoard Edge database
+### Step 2. Configure ThingsBoard Edge Database
 
-{% include templates/install/install-db.md %}
+**ThingsBoard Edge** supports **SQL** and **hybrid** database approaches. See the architecture [page](/docs/reference/#sql-vs-nosql-vs-hybrid-database-approach){: target="_blank"} for details.
 
 {% capture contenttogglespec %}
 PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/edge/install/ubuntu-db-postgresql.md%br%
-Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/ubuntu-db-hybrid.md{% endcapture %}
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/edge/install/ubuntu-db-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardDatabase" toggle-spec=contenttogglespec %}
 
-### Step 3. Choose queue service
-**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+### Step 3. Choose Queue Service
 
-* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+**ThingsBoard Edge** can use different messaging systems and brokers for storing messages and enabling communication between its services. Choose the appropriate queue implementation based on your specific business needs:
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **In Memory**: The built-in and default queue implementation. It is useful for development or proof-of-concept (PoC) environments, but is not recommended for production or any type of clustered deployments due to limited scalability.
+
+* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you want to stay independent of your cloud provider. However, some providers also offer managed services for Kafka. See for example [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"}.
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/ubuntu-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/ubuntu-queue-kafka.md%br%
+Kafka in docker container <small>(recommended for on-prem, production installations)</small>%,%kafka-in-docker%,%templates/edge/install/ubuntu-queue-kafka-in-docker.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-### Step 4. ThingsBoard Edge service installation
+### Step 4. ThingsBoard Edge Service Installation
 
-Download installation package.
+Download the installation package.
 
 ```bash
 wget https://github.com/thingsboard/thingsboard-edge/releases/download/{{ site.release.edge_tag }}/tb-edge-{{ site.release.edge_ver }}.deb
@@ -69,11 +71,11 @@ sudo dpkg -i tb-edge-{{ site.release.edge_ver }}.deb
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 6. Run installation script
+### Step 6. Run installation Script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge Service
 
 ```bash
 sudo service tb-edge restart
@@ -86,7 +88,7 @@ sudo service tb-edge restart
 
 ## Troubleshooting
 
-ThingsBoard Edge logs stored in the following directory:
+**ThingsBoard Edge** logs stored in the following directory:
  
 ```bash
 /var/log/tb-edge

--- a/docs/user-guide/install/edge/deb-installation.md
+++ b/docs/user-guide/install/edge/deb-installation.md
@@ -12,7 +12,7 @@ description: Installing ThingsBoard Edge on Ubuntu Server
 
 {% assign docsPrefix = "edge/" %}
 
-This guide describes how to install ThingsBoard Edge on Ubuntu 18.04 LTS / Ubuntu 20.04 LTS.
+This guide describes how to install **ThingsBoard Edge** on Ubuntu 18.04 LTS / Ubuntu 20.04 LTS.
 
 {% include templates/edge/install/prerequisites.md %}
 

--- a/docs/user-guide/install/edge/deb-installation.md
+++ b/docs/user-guide/install/edge/deb-installation.md
@@ -26,11 +26,30 @@ This guide describes how to install ThingsBoard Edge on Ubuntu 18.04 LTS / Ubunt
 
 {% include templates/install/ubuntu-java-install.md %}
 
-### Step 2. Configure PostgreSQL
+### Step 2. Configure ThingsBoard Edge database
 
-{% include templates/edge/install/ubuntu-db-postgresql.md %}
+{% include templates/install/install-db.md %}
 
-### Step 3. ThingsBoard Edge service installation
+{% capture contenttogglespec %}
+PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/edge/install/ubuntu-db-postgresql.md%br%
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/ubuntu-db-hybrid.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardDatabase" toggle-spec=contenttogglespec %}
+
+### Step 3. Choose queue service
+**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+
+* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+
+{% capture contenttogglespecqueue %}
+In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/ubuntu-queue-kafka.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
+
+### Step 4. ThingsBoard Edge service installation
 
 Download installation package.
 
@@ -46,22 +65,22 @@ sudo dpkg -i tb-edge-{{ site.release.edge_ver }}.deb
 ```
 {: .copy-code}
 
-### Step 4. Configure ThingsBoard Edge
+### Step 5. Configure ThingsBoard Edge
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 5. Run installation script
+### Step 6. Run installation script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 6. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge service
 
 ```bash
 sudo service tb-edge restart
 ```
 {: .copy-code}
 
-### Step 7. Open ThingsBoard Edge UI
+### Step 8. Open ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %} 
 

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -35,64 +35,25 @@ This guide will help you to install and start ThingsBoard Edge using Docker on L
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
+### Step 2. Choose queue service
+**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+
+* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
 Create docker compose file for ThingsBoard Edge service:
 
-```text
-nano docker-compose.yml
-```
-{: .copy-code}
+{% capture contenttogglespecqueue %}
+In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/docker-queue-in-memory.md%br%
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/install/docker-queue-kafka.md{% endcapture %}
 
-Add the following lines to the yml file:
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-```yml
-version: '3.8'
-services:
-  mytbedge:
-    restart: always
-    image: "thingsboard/tb-edge:{{ site.release.edge_full_ver }}"
-    ports:
-      - "8080:8080"
-      - "1883:1883"
-      - "5683-5688:5683-5688/udp"
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
-      CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
-      CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
-      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
-    volumes:
-      - tb-edge-data:/data
-      - tb-edge-logs:/var/log/tb-edge
-  postgres:
-    restart: always
-    image: "postgres:15"
-    ports:
-      - "5432"
-    environment:
-      POSTGRES_DB: tb-edge
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - tb-edge-postgres-data:/var/lib/postgresql/data
-
-volumes:
-  tb-edge-data:
-    name: tb-edge-data
-  tb-edge-logs:
-    name: tb-edge-logs
-  tb-edge-postgres-data:
-    name: tb-edge-postgres-data
-```
-{: .copy-code}
-
-{% include templates/edge/install/docker_compose_details_explain.md %}
-
-{% assign serviceName = "tbedge" %}
-{% include templates/install/docker/docker-compose-up.md %}
-
-### Step 2. Open ThingsBoard Edge UI
+### Step 3. Open ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %}
 
-### Step 3. Detaching, stop and start commands
+### Step 4. Detaching, stop and start commands
 
 {% assign serviceFullName = "ThingsBoard Edge" %}
 {% include templates/install/docker/detaching-stop-start-commands.md %}

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -43,7 +43,7 @@ This guide will help you to install and start **ThingsBoard Edge** using **Docke
 
 * **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
 
-* **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended to use a hybrid database approach if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
+* **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
 
 Create a docker compose file for the **ThingsBoard Edge** service:
 

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -35,13 +35,13 @@ This guide will help you to install and start **ThingsBoard Edge** using **Docke
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
-### Step 2. Choose Queue Service
+### Step 2. Choose Queue and/or Database Services
 
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now.
 
 * **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
 

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -12,7 +12,7 @@ description: Installing ThingsBoard Edge using Docker (Linux or Mac OS)
 
 {% assign docsPrefix = "edge/" %}
 
-This guide will help you to install and start ThingsBoard Edge using Docker on Linux or Mac OS.
+This guide will help you to install and start **ThingsBoard Edge** using **Docker** on Linux or Mac OS.
 
 {% include templates/edge/install/prerequisites.md %}
 
@@ -35,7 +35,8 @@ This guide will help you to install and start ThingsBoard Edge using Docker on L
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
-### Step 2. Choose queue service
+### Step 2. Choose Queue Service
+
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
@@ -45,7 +46,7 @@ Create docker compose file for ThingsBoard Edge service:
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/docker-queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/install/docker-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/docker-queue-kafka.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
@@ -53,7 +54,7 @@ Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka
 
 {% include templates/edge/install/open-edge-ui.md %}
 
-### Step 4. Detaching, stop and start commands
+### Step 4. Detaching, Stop and Start Commands
 
 {% assign serviceFullName = "ThingsBoard Edge" %}
 {% include templates/install/docker/detaching-stop-start-commands.md %}

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -42,11 +42,15 @@ This guide will help you to install and start **ThingsBoard Edge** using **Docke
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
 * **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
-Create docker compose file for ThingsBoard Edge service:
+
+* **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended to use a hybrid database approach if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
+
+Create a docker compose file for the **ThingsBoard Edge** service:
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/docker-queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/docker-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/docker-queue-kafka.md%br%
+Hybrid <small>(PostgreSQL+Cassandra with Kafka queue service)</small>%,%hybrid%,%templates/edge/install/docker-queue-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 

--- a/docs/user-guide/install/edge/resources/3.9/tb-edge-centos-download.sh
+++ b/docs/user-guide/install/edge/resources/3.9/tb-edge-centos-download.sh
@@ -1,0 +1,1 @@
+wget https://github.com/thingsboard/thingsboard-edge/releases/download/v3.9/tb-edge-3.9.rpm

--- a/docs/user-guide/install/edge/resources/3.9/tb-edge-centos-installation.sh
+++ b/docs/user-guide/install/edge/resources/3.9/tb-edge-centos-installation.sh
@@ -1,0 +1,1 @@
+sudo rpm -Uvh tb-edge-3.9.rpm

--- a/docs/user-guide/install/edge/resources/3.9/tb-edge-ubuntu-download.sh
+++ b/docs/user-guide/install/edge/resources/3.9/tb-edge-ubuntu-download.sh
@@ -1,0 +1,1 @@
+wget https://github.com/thingsboard/thingsboard-edge/releases/download/v3.9/tb-edge-3.9.deb

--- a/docs/user-guide/install/edge/resources/3.9/tb-edge-ubuntu-installation.sh
+++ b/docs/user-guide/install/edge/resources/3.9/tb-edge-ubuntu-installation.sh
@@ -1,0 +1,1 @@
+sudo dpkg -i tb-edge-3.9.deb

--- a/docs/user-guide/install/edge/rhel.md
+++ b/docs/user-guide/install/edge/rhel.md
@@ -49,7 +49,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. 
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%

--- a/docs/user-guide/install/edge/rhel.md
+++ b/docs/user-guide/install/edge/rhel.md
@@ -34,11 +34,30 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 
 {% include templates/install/rhel-java-install.md %}
 
-### Step 2. Configure PostgreSQL
+### Step 2. Configure ThingsBoard database
 
-{% include templates/edge/install/rhel-db-postgresql.md %}
+{% include templates/install/install-db.md %}
 
-### Step 3. ThingsBoard Edge service installation
+{% capture contenttogglespec %}
+PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/install/rhel-db-postgresql.md%br%
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/rhel-db-hybrid.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="rhelThingsboardDatabase" toggle-spec=contenttogglespec %}
+
+### Step 3. Choose queue service
+**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+
+* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+
+{% capture contenttogglespecqueue %}
+In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/ubuntu-queue-kafka.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
+
+### Step 4. ThingsBoard Edge service installation
 
 Download installation package.
 
@@ -55,22 +74,22 @@ sudo rpm -Uvh tb-edge-{{ site.release.edge_ver }}.rpm
 {: .copy-code}
 
 
-### Step 4. Configure ThingsBoard Edge
+### Step 5. Configure ThingsBoard Edge
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 5. Run installation script
+### Step 6. Run installation script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 6. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge service
 
 ```bash
 sudo service tb-edge restart
 ```
 {: .copy-code}
 
-### Step 7. Open ThingsBoard Edge UI
+### Step 8. Open ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %} 
 

--- a/docs/user-guide/install/edge/rhel.md
+++ b/docs/user-guide/install/edge/rhel.md
@@ -11,7 +11,7 @@ description: Installing ThingsBoard Edge on CentOS/RHEL Server
 
 {% assign docsPrefix = "edge/" %}
 
-This guide describes how to install ThingsBoard Edge on RHEL/CentOS 7/8.
+This guide describes how to install **ThingsBoard Edge** on **RHEL/CentOS 7/8.**
 
 {% include templates/edge/install/prerequisites.md %}
 
@@ -34,13 +34,13 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 
 {% include templates/install/rhel-java-install.md %}
 
-### Step 2. Configure ThingsBoard database
+### Step 2. Configure ThingsBoard Database
 
-{% include templates/install/install-db.md %}
+**ThingsBoard Edge** supports **SQL** and **hybrid** database approaches. See the architecture [page](/docs/reference/#sql-vs-nosql-vs-hybrid-database-approach){: target="_blank"} for details.
 
 {% capture contenttogglespec %}
-PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/install/rhel-db-postgresql.md%br%
-Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/rhel-db-hybrid.md{% endcapture %}
+PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/edge/install/rhel-db-postgresql.md%br%
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/edge/install/rhel-db-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="rhelThingsboardDatabase" toggle-spec=contenttogglespec %}
 
@@ -53,11 +53,11 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/rhel-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/edge/install/rhel-queue-kafka.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-### Step 4. ThingsBoard Edge service installation
+### Step 4. ThingsBoard Edge Service Installation
 
 Download installation package.
 
@@ -78,11 +78,11 @@ sudo rpm -Uvh tb-edge-{{ site.release.edge_ver }}.rpm
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 6. Run installation script
+### Step 6. Run installation Script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge Service
 
 ```bash
 sudo service tb-edge restart

--- a/docs/user-guide/install/edge/rhel.md
+++ b/docs/user-guide/install/edge/rhel.md
@@ -44,7 +44,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 {% include content-toggle.liquid content-toggle-id="rhelThingsboardDatabase" toggle-spec=contenttogglespec %}
 
-### Step 3. Choose queue service
+### Step 3. Choose Queue Service
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.

--- a/docs/user-guide/install/edge/rhel.md
+++ b/docs/user-guide/install/edge/rhel.md
@@ -53,7 +53,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/ubuntu-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/rhel-queue-kafka.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 

--- a/docs/user-guide/install/edge/upgrade-instructions.md
+++ b/docs/user-guide/install/edge/upgrade-instructions.md
@@ -22,6 +22,20 @@ description: ThingsBoard Edge upgrade instructions
         </ul>
     </li>
     <li>
+        <a href="#upgrading-to-39" id="markdown-toc-upgrading-to-39">Upgrading to 3.9EDGE</a>
+        <ul>
+            <li>
+                <a href="#ubuntucentos-39" id="markdown-toc-ubuntucentos-39">Ubuntu/CentOS</a>
+            </li>
+            <li>
+                <a href="#docker-linux-mac-39" id="markdown-toc-docker-linux-mac-39">Docker (Linux or Mac OS)</a>
+            </li>
+            <li>
+                <a href="#windows-39" id="markdown-toc-windows-39">Windows</a>
+            </li> 
+        </ul>
+    </li>
+    <li>
         <a href="#upgrading-to-38" id="markdown-toc-upgrading-to-38">Upgrading to 3.8EDGE</a>
         <ul>
             <li>
@@ -251,6 +265,197 @@ net stop tb-edge
 Launch the "pgAdmin" software and login as superuser (postgres). 
 Open your server and create backup of database **tb_edge** using 'Backup Dialog' functionality of "pgAdmin".
 
+## Upgrading to 3.9EDGE {#upgrading-to-39}
+
+{% assign serverVersion = "3.9" %}
+{% assign updateServerLink = "#upgrading-to-39" %}
+{% include templates/edge/install/compatibility-warning-version.md %}
+
+### Ubuntu/CentOS {#ubuntucentos-39}
+
+**NOTE**: These steps are applicable for ThingsBoard Edge 3.8EDGE version.
+
+#### ThingsBoard Edge package download
+
+{% capture tabspec %}tb-edge-download-3-9-0
+tb-edge-download-3-9-0-ubuntu,Ubuntu,shell,resources/3.9/tb-edge-ubuntu-download.sh,/docs/user-guide/install/edge/resources/3.9/tb-edge-ubuntu-download.sh
+tb-edge-download-3-9-0-centos,CentOS,shell,resources/3.9/tb-edge-centos-download.sh,/docs/user-guide/install/edge/resources/3.9/tb-edge-centos-download.sh{% endcapture %}
+{% include tabs.html %}
+
+#### ThingsBoard Edge service upgrade
+
+* Stop ThingsBoard Edge service if it is running.
+
+```bash
+sudo service tb-edge stop
+```
+{: .copy-code}
+
+{% capture tabspec %}tb-edge-installation-3-9-0
+tb-edge-installation-3-9-0-ubuntu,Ubuntu,shell,resources/3.9/tb-edge-ubuntu-installation.sh,/docs/user-guide/install/edge/resources/3.9/tb-edge-ubuntu-installation.sh
+tb-edge-installation-3-9-0-centos,CentOS,shell,resources/3.9/tb-edge-centos-installation.sh,/docs/user-guide/install/edge/resources/3.9/tb-edge-centos-installation.sh{% endcapture %}
+{% include tabs.html %}
+
+**NOTE:** Package installer may ask you to merge your tb-edge configuration. It is preferred to use **merge option** to make sure that all your previous parameters will not be overwritten.
+
+Execute regular upgrade script:
+
+```bash
+sudo /usr/share/tb-edge/bin/install/upgrade.sh --fromVersion=3.8.0
+```
+{: .copy-code}
+
+#### Start the service
+
+```bash
+sudo service tb-edge start
+```
+{: .copy-code}
+
+### Docker (Linux or Mac OS) {#docker-linux-mac-39}
+
+**NOTE**: These steps are applicable for ThingsBoard Edge 3.8EDGE version.
+
+Set the terminal in the directory which contains the `docker-compose.yml` file and execute the following command to stop and remove currently running TB Edge container (if it's still running):
+```
+docker compose stop
+docker compose rm mytbedge
+```
+{: .copy-code}
+
+#### Backup Database
+Make a copy of the database volume before upgrading:
+
+```bash
+docker run --rm -v tb-edge-postgres-data:/source -v tb-edge-postgres-data-backup:/backup busybox sh -c "cp -a /source/. /backup"
+```
+{: .copy-code}
+
+Create docker compose file for ThingsBoard Edge upgrade process:
+
+```text
+> docker-compose-upgrade.yml && nano docker-compose-upgrade.yml
+```
+{: .copy-code}
+
+Add the following lines to the yml file:
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: on-failure
+    image: "thingsboard/tb-edge:3.9.0EDGE"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+    entrypoint: upgrade-tb-edge.sh
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_DB: tb-edge
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - tb-edge-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  tb-edge-data:
+    name: tb-edge-data
+  tb-edge-logs:
+    name: tb-edge-logs
+  tb-edge-postgres-data:
+    name: tb-edge-postgres-data
+```
+{: .copy-code}
+
+Execute the following command to start upgrade process:
+```
+docker compose -f docker-compose-upgrade.yml up
+```
+{: .copy-code}
+
+Once upgrade process successfully completed, exit from the docker-compose shell by this combination:
+```
+Ctrl + C
+```
+
+Execute the following command to stop TB Edge upgrade container:
+```
+docker compose -f docker-compose-upgrade.yml stop
+```
+{: .copy-code}
+
+Modify 'main' docker compose (`docker-compose.yml`) file for ThingsBoard Edge and update version of the image:
+
+```text
+nano docker-compose.yml
+```
+{: .copy-code}
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: always
+    image: "thingsboard/tb-edge:3.9.0EDGE"
+...
+```
+
+Make sure your image is the set to tb-edge-**3.9.0EDGE**.
+
+Execute the following commands to up this docker compose directly:
+```
+docker compose up -d
+docker compose logs -f mytbedge
+```
+{: .copy-code}
+
+
+### Windows {#windows-39}
+
+**NOTE**: These steps are applicable for ThingsBoard Edge 3.8EDGE version.
+
+#### ThingsBoard Edge package download
+
+Download ThingsBoard Edge package for Windows: [tb-edge-windows-3.9.zip](https://github.com/thingsboard/thingsboard-edge/releases/download/v3.9/tb-edge-windows-3.9.zip).
+
+#### ThingsBoard Edge service upgrade
+
+* Stop ThingsBoard Edge service if it is running:
+
+```text
+net stop tb-edge
+```
+{: .copy-code}
+
+* Make a backup of previous ThingsBoard Edge configuration located in *\<ThingsBoard Edge install dir\>\conf* (for example: *C:\tb-edge\conf*).
+
+* Extract ThingsBoard Edge package.
+
+* Compare and merge your old ThingsBoard Edge configuration files (from the backup you made in the previous step) with new ones.
+
+* Finally, run **upgrade.bat** script to upgrade ThingsBoard Edge to the new version.
+
+**NOTE** Scripts listed below should be executed using Administrator Role.
+
+Execute regular upgrade script:
+
+```text
+C:\tb-edge>upgrade.bat --fromVersion=3.8.0
+```
+
+#### Start the service
+
+```text
+net start tb-edge
+```
+{: .copy-code}
+
 ## Upgrading to 3.8EDGE {#upgrading-to-38}
 
 {% assign serverVersion = "3.8" %}
@@ -408,7 +613,7 @@ docker compose logs -f mytbedge
 
 #### ThingsBoard Edge package download
 
-Download ThingsBoard Edge package for Windows: [tb-edge-windows-3.8.zip](https://github.com/thingsboard/thingsboard-edge/releases/download/v3.8/tb-edge-windows-3.8.0.zip).
+Download ThingsBoard Edge package for Windows: [tb-edge-windows-3.8.zip](https://github.com/thingsboard/thingsboard-edge/releases/download/v3.8/tb-edge-windows-3.8.zip).
 
 #### ThingsBoard Edge service upgrade
 

--- a/docs/user-guide/install/pe/edge/deb-installation.md
+++ b/docs/user-guide/install/pe/edge/deb-installation.md
@@ -42,7 +42,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 * **In Memory**: The built-in and default queue implementation. It is useful for development or proof-of-concept (PoC) environments, but is not recommended for production or any type of clustered deployments due to limited scalability.
 
-* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you want to stay independent of your cloud provider. However, some providers also offer managed services for Kafka. See for example [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"}.
+* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now.
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%

--- a/docs/user-guide/install/pe/edge/deb-installation.md
+++ b/docs/user-guide/install/pe/edge/deb-installation.md
@@ -26,11 +26,30 @@ This guide describes how to install ThingsBoard Edge on Ubuntu 18.04 LTS / Ubunt
 
 {% include templates/install/ubuntu-java-install.md %}
 
-### Step 2. Configure PostgreSQL
+### Step 2. Configure ThingsBoard Edge database
 
-{% include templates/edge/install/ubuntu-db-postgresql.md %}
+{% include templates/install/install-db.md %}
 
-### Step 3. ThingsBoard Edge service installation
+{% capture contenttogglespec %}
+PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/edge/install/ubuntu-db-postgresql.md%br%
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/ubuntu-db-hybrid.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardDatabase" toggle-spec=contenttogglespec %}
+
+### Step 3. Choose queue service
+**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+
+* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+
+{% capture contenttogglespecqueue %}
+In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/ubuntu-queue-kafka.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
+
+### Step 4. ThingsBoard Edge service installation
 
 Download installation package.
 
@@ -46,22 +65,22 @@ sudo dpkg -i tb-edge-{{ site.release.pe_edge_ver }}.deb
 ```
 {: .copy-code}
 
-### Step 4. Configure ThingsBoard Edge
+### Step 5. Configure ThingsBoard Edge
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 5. Run installation script
+### Step 6. Run installation script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 6. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge service
 
 ```bash
 sudo service tb-edge restart
 ```
 {: .copy-code}
 
-### Step 7. Open ThingsBoard Edge UI
+### Step 8. Open ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %} 
 

--- a/docs/user-guide/install/pe/edge/deb-installation.md
+++ b/docs/user-guide/install/pe/edge/deb-installation.md
@@ -12,7 +12,7 @@ description: Installing ThingsBoard Edge on Ubuntu Server
 
 {% assign docsPrefix = "pe/edge/" %}
 
-This guide describes how to install ThingsBoard Edge on Ubuntu 18.04 LTS / Ubuntu 20.04 LTS.
+This guide describes how to install **ThingsBoard Edge** on Ubuntu 18.04 LTS / Ubuntu 20.04 LTS.
 
 {% include templates/edge/install/prerequisites.md %}
 
@@ -26,39 +26,41 @@ This guide describes how to install ThingsBoard Edge on Ubuntu 18.04 LTS / Ubunt
 
 {% include templates/install/ubuntu-java-install.md %}
 
-### Step 2. Configure ThingsBoard Edge database
+### Step 2. Configure ThingsBoard Edge Database
 
-{% include templates/install/install-db.md %}
+**ThingsBoard Edge** supports **SQL** and **hybrid** database approaches. See the architecture [page](/docs/pe/reference/#sql-vs-nosql-vs-hybrid-database-approach){: target="_blank"} for details.
 
 {% capture contenttogglespec %}
 PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/edge/install/ubuntu-db-postgresql.md%br%
-Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/ubuntu-db-hybrid.md{% endcapture %}
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/edge/install/ubuntu-db-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardDatabase" toggle-spec=contenttogglespec %}
 
-### Step 3. Choose queue service
-**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+### Step 3. Choose Queue Service
 
-* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+**ThingsBoard Edge** can use different messaging systems and brokers for storing messages and enabling communication between its services. Choose the appropriate queue implementation based on your specific business needs:
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **In Memory**: The built-in and default queue implementation. It is useful for development or proof-of-concept (PoC) environments, but is not recommended for production or any type of clustered deployments due to limited scalability.
+
+* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you want to stay independent of your cloud provider. However, some providers also offer managed services for Kafka. See for example [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"}.
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/ubuntu-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/ubuntu-queue-kafka.md%br%
+Kafka in docker container <small>(recommended for on-prem, production installations)</small>%,%kafka-in-docker%,%templates/edge/install/ubuntu-queue-kafka-in-docker.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-### Step 4. ThingsBoard Edge service installation
+### Step 4. ThingsBoard Edge Service Installation
 
-Download installation package.
+Download the installation package.
 
 ```bash
 wget https://dist.thingsboard.io/tb-edge-{{ site.release.pe_edge_ver }}.deb
 ```
 {: .copy-code}
 
-Go to the download repository and install ThingsBoard Edge service
+Go to the download repository and install **ThingsBoard Edge** service:
 
 ```bash
 sudo dpkg -i tb-edge-{{ site.release.pe_edge_ver }}.deb
@@ -73,7 +75,7 @@ sudo dpkg -i tb-edge-{{ site.release.pe_edge_ver }}.deb
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge Service
 
 ```bash
 sudo service tb-edge restart

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -35,13 +35,13 @@ This guide will help you to install and start **ThingsBoard Edge** using **Docke
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
-### Step 2. Choose Queue Service
+### Step 2. Choose Queue and/or Database Services
 
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent of your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now.
 
 * **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -50,7 +50,7 @@ Create a docker compose file for the **ThingsBoard Edge** service:
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/pe-docker-queue-in-memory.md%br%
 Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/pe-docker-queue-kafka.md%br%
-Hybrid <small>PostgreSQL+Cassandra with Kafka as the queue service </small>%,%hybrid%,%templates/edge/install/pe-docker-queue-hybrid.md{% endcapture %}
+Hybrid <small>PostgreSQL+Cassandra with Kafka queue service </small>%,%hybrid%,%templates/edge/install/pe-docker-queue-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -43,7 +43,7 @@ This guide will help you to install and start **ThingsBoard Edge** using **Docke
 
 * **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent of your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
 
-* **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended to use a hybrid database approach if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
+* **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
 
 Create a docker compose file for the **ThingsBoard Edge** service:
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -12,11 +12,11 @@ description: Installing ThingsBoard Edge using Docker (Linux or Mac OS)
 
 {% assign docsPrefix = "pe/edge/" %}
 
-This guide will help you to install and start ThingsBoard Edge using Docker on Linux or Mac OS.
+This guide will help you to install and start **ThingsBoard Edge** using **Docker** on Linux or Mac OS.
 
 {% include templates/edge/install/prerequisites.md %}
 
-### Docker installation
+### Docker Installation
 
 - [Install Docker CE](https://docs.docker.com/engine/install/){:target="_blank"}
 - [Install Docker Compose](https://docs.docker.com/compose/install/){:target="_blank"}
@@ -35,7 +35,8 @@ This guide will help you to install and start ThingsBoard Edge using Docker on L
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
-### Step 2. Choose queue service
+### Step 2. Choose Queue Service
+
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
@@ -44,7 +45,7 @@ This guide will help you to install and start ThingsBoard Edge using Docker on L
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/pe-docker-queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/install/pe-docker-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/pe-docker-queue-kafka.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
@@ -52,7 +53,7 @@ Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka
 
 {% include templates/edge/install/open-edge-ui.md %}
 
-### Step 4. Detaching, stop and start commands
+### Step 4. Detaching, Stop and Start Commands
 
 {% assign serviceFullName = "ThingsBoard Edge" %}
 {% include templates/install/docker/detaching-stop-start-commands.md %}

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -41,11 +41,16 @@ This guide will help you to install and start **ThingsBoard Edge** using **Docke
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent of your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+
+* **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended to use a hybrid database approach if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
+
+Create a docker compose file for the **ThingsBoard Edge** service:
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/pe-docker-queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/pe-docker-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/edge/install/pe-docker-queue-kafka.md%br%
+Hybrid <small>PostgreSQL+Cassandra with Kafka as the queue service </small>%,%hybrid%,%templates/edge/install/pe-docker-queue-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -35,66 +35,24 @@ This guide will help you to install and start ThingsBoard Edge using Docker on L
 
 {% include templates/edge/install/copy-edge-credentials.md %}
 
-Create docker compose file for ThingsBoard Edge service:
+### Step 2. Choose queue service
+**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
-```text
-nano docker-compose.yml
-```
-{: .copy-code}
+* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-Add the following lines to the yml file:
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
 
-```yml
-version: '3.8'
-services:
-  mytbedge:
-    restart: always
-    image: "thingsboard/tb-edge-pe:{{ site.release.pe_edge_full_ver }}"
-    ports:
-      - "8080:8080"
-      - "1883:1883"
-      - "5683-5688:5683-5688/udp"
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
-      EDGE_LICENSE_INSTANCE_DATA_FILE: /data/instance-edge-license.data
-      CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
-      CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
-      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or thingsboard.cloud
-      CLOUD_RPC_SSL_ENABLED: 'false' # set it to 'true' if you are connecting edge to thingsboard.cloud 
-    volumes:
-      - tb-edge-data:/data
-      - tb-edge-logs:/var/log/tb-edge
-  postgres:
-    restart: always
-    image: "postgres:15"
-    ports:
-      - "5432"
-    environment:
-      POSTGRES_DB: tb-edge
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - tb-edge-postgres-data:/var/lib/postgresql/data
+{% capture contenttogglespecqueue %}
+In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/edge/pe-docker-queue-in-memory.md%br%
+Kafka <small>(recommended for on-prem, production installations)</small>%,%kafka%,%templates/install/pe-docker-queue-kafka.md{% endcapture %}
 
-volumes:
-  tb-edge-data:
-    name: tb-edge-data
-  tb-edge-logs:
-    name: tb-edge-logs
-  tb-edge-postgres-data:
-    name: tb-edge-postgres-data
-```
-{: .copy-code}
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-{% include templates/edge/install/docker_compose_details_explain.md %}
-
-{% assign serviceName = "tbedge" %}
-{% include templates/install/docker/docker-compose-up.md %}
-
-### Step 2. Open ThingsBoard Edge UI
+### Step 3. Open ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %}
 
-### Step 3. Detaching, stop and start commands
+### Step 4. Detaching, stop and start commands
 
 {% assign serviceFullName = "ThingsBoard Edge" %}
 {% include templates/install/docker/detaching-stop-start-commands.md %}

--- a/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-centos-download.sh
+++ b/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-centos-download.sh
@@ -1,0 +1,1 @@
+wget https://dist.thingsboard.io/tb-edge-3.9pe.rpm

--- a/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-centos-installation.sh
+++ b/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-centos-installation.sh
@@ -1,0 +1,1 @@
+sudo rpm -Uvh tb-edge-3.9pe.rpm

--- a/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-ubuntu-download.sh
+++ b/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-ubuntu-download.sh
@@ -1,0 +1,1 @@
+wget https://dist.thingsboard.io/tb-edge-3.9pe.deb

--- a/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-ubuntu-installation.sh
+++ b/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-ubuntu-installation.sh
@@ -1,0 +1,1 @@
+sudo dpkg -i tb-edge-3.9pe.deb

--- a/docs/user-guide/install/pe/edge/rhel.md
+++ b/docs/user-guide/install/pe/edge/rhel.md
@@ -33,11 +33,30 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 
 {% include templates/install/rhel-java-install.md %}
 
-### Step 2. Configure PostgreSQL
+### Step 2. Configure ThingsBoard database
 
-{% include templates/edge/install/rhel-db-postgresql.md %}
+{% include templates/install/install-db.md %}
 
-### Step 3. ThingsBoard Edge service installation
+{% capture contenttogglespec %}
+PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/install/rhel-db-postgresql.md%br%
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/rhel-db-hybrid.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="rhelThingsboardDatabase" toggle-spec=contenttogglespec %}
+
+### Step 3. Choose queue service
+**ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
+
+* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+
+{% capture contenttogglespecqueue %}
+In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/rhel-queue-kafka.md{% endcapture %}
+
+{% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
+
+### Step 4. ThingsBoard Edge service installation
 
 Download installation package.
 
@@ -54,21 +73,21 @@ sudo rpm -Uvh tb-edge-{{ site.release.pe_edge_ver }}.rpm
 {: .copy-code}
 
 
-### Step 4. Configure ThingsBoard Edge
+### Step 5. Configure ThingsBoard Edge
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 5. Run installation script
+### Step 6. Run installation script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 6. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge service
 
 ```bash
 sudo service tb-edge restart
 ```
 
-### Step 7. Open ThingsBoard Edge UI
+### Step 8. Open ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %} 
 

--- a/docs/user-guide/install/pe/edge/rhel.md
+++ b/docs/user-guide/install/pe/edge/rhel.md
@@ -49,7 +49,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now. It is useful for both on-prem and private cloud deployments. It is also useful if you like to stay independent from your cloud provider. However, some providers also have managed services for Kafka. See [AWS MSK](https://aws.amazon.com/msk/){: target="_blank"} for example.
+* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now.
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%

--- a/docs/user-guide/install/pe/edge/rhel.md
+++ b/docs/user-guide/install/pe/edge/rhel.md
@@ -11,7 +11,7 @@ description: Installing ThingsBoard Edge on CentOS/RHEL Server
 
 {% assign docsPrefix = "pe/edge/" %}
 
-This guide describes how to install ThingsBoard Edge on RHEL/CentOS 7/8.
+This guide describes how to install **ThingsBoard Edge** on **RHEL/CentOS 7/8.**
 
 {% include templates/edge/install/prerequisites.md %}
 
@@ -33,17 +33,18 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 
 {% include templates/install/rhel-java-install.md %}
 
-### Step 2. Configure ThingsBoard database
+### Step 2. Configure ThingsBoard Database
 
-{% include templates/install/install-db.md %}
+**ThingsBoard Edge** supports **SQL** and **hybrid** database approaches. See the architecture [page](/docs/pe/reference/#sql-vs-nosql-vs-hybrid-database-approach){: target="_blank"} for details.
 
 {% capture contenttogglespec %}
-PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/install/rhel-db-postgresql.md%br%
-Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/install/rhel-db-hybrid.md{% endcapture %}
+PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%templates/edge/install/rhel-db-postgresql.md%br%
+Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/edge/install/rhel-db-hybrid.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="rhelThingsboardDatabase" toggle-spec=contenttogglespec %}
 
 ### Step 3. Choose queue service
+
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
 * **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
@@ -52,11 +53,11 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
-Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/install/rhel-queue-kafka.md{% endcapture %}
+Kafka <small>(recommended for on-prem, production installations)</small> %,%kafka%,%templates/edge/install/rhel-queue-kafka.md{% endcapture %}
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-### Step 4. ThingsBoard Edge service installation
+### Step 4. ThingsBoard Edge Service Installation
 
 Download installation package.
 
@@ -77,11 +78,11 @@ sudo rpm -Uvh tb-edge-{{ site.release.pe_edge_ver }}.rpm
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 6. Run installation script
+### Step 6. Run installation Script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Restart ThingsBoard Edge service
+### Step 7. Restart ThingsBoard Edge Service
 
 ```bash
 sudo service tb-edge restart

--- a/docs/user-guide/install/pe/edge/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/edge/upgrade-instructions.md
@@ -22,6 +22,20 @@ description: ThingsBoard PE Edge upgrade instructions
         </ul>
     </li>
     <li>
+        <a href="#upgrading-to-39" id="markdown-toc-upgrading-to-39">Upgrading to 3.9EDGEPE</a>
+        <ul>
+            <li>
+                <a href="#ubuntucentos-39" id="markdown-toc-ubuntucentos-39">Ubuntu/CentOS</a>
+            </li>
+            <li>
+                <a href="#docker-linux-mac-39" id="markdown-toc-docker-linux-mac-39">Docker (Linux or Mac OS)</a>
+            </li>
+            <li>
+                <a href="#windows-39" id="markdown-toc-windows-39">Windows</a>
+            </li> 
+        </ul>
+    </li>
+    <li>
         <a href="#upgrading-to-38" id="markdown-toc-upgrading-to-38">Upgrading to 3.8EDGEPE</a>
         <ul>
             <li>
@@ -252,6 +266,196 @@ net stop tb-edge
 
 Launch the "pgAdmin" software and login as superuser (postgres). 
 Open your server and create backup of database **tb_edge** using 'Backup Dialog' functionality of "pgAdmin".
+## Upgrading to 3.9EDGEPE {#upgrading-to-39}
+
+{% assign serverVersion = "3.9PE" %}
+{% assign updateServerLink = "#upgrading-to-39pe" %}
+{% include templates/edge/install/compatibility-warning-version.md %}
+
+### Ubuntu/CentOS {#ubuntucentos-39}
+
+**NOTE**: These steps are applicable for ThingsBoard Edge 3.8EDGEPE version.
+
+#### ThingsBoard Edge package download
+
+{% capture tabspec %}tb-edge-pe-download-3-9-0
+tb-edge-pe-download-3-9-0-ubuntu,Ubuntu,shell,resources/3.9/tb-edge-ubuntu-download.sh,/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-ubuntu-download.sh
+tb-edge-pe-download-3-9-0-centos,CentOS,shell,resources/3.9/tb-edge-centos-download.sh,/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-centos-download.sh{% endcapture %}
+{% include tabs.html %}
+
+#### ThingsBoard Edge service upgrade
+
+* Stop ThingsBoard Edge service if it is running.
+
+```bash
+sudo service tb-edge stop
+```
+{: .copy-code}
+
+{% capture tabspec %}tb-edge-pe-installation-3-9-0
+tb-edge-pe-installation-3-9-0-ubuntu,Ubuntu,shell,resources/3.9/tb-edge-ubuntu-installation.sh,/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-ubuntu-installation.sh
+tb-edge-pe-installation-3-9-0-centos,CentOS,shell,resources/3.9/tb-edge-centos-installation.sh,/docs/user-guide/install/pe/edge/resources/3.9/tb-edge-centos-installation.sh{% endcapture %}
+{% include tabs.html %}
+
+**NOTE:** Package installer may ask you to merge your tb-edge configuration. It is preferred to use **merge option** to make sure that all your previous parameters will not be overwritten.
+
+Execute regular upgrade script:
+
+```bash
+sudo /usr/share/tb-edge/bin/install/upgrade.sh --fromVersion=3.8.0
+```
+{: .copy-code}
+
+#### Start the service
+
+```bash
+sudo service tb-edge start
+```
+{: .copy-code}
+
+### Docker (Linux or Mac OS) {#docker-linux-mac-39}
+
+**NOTE**: These steps are applicable for ThingsBoard Edge 3.8EDGEPE version.
+
+Set the terminal in the directory which contains the `docker-compose.yml` file and execute the following command to stop and remove currently running TB Edge container (if it's still running):
+```
+docker compose stop
+docker compose rm mytbedge
+```
+{: .copy-code}
+
+#### Backup Database
+Make a copy of the database volume before upgrading:
+
+```bash
+docker run --rm -v tb-edge-postgres-data:/source -v tb-edge-postgres-data-backup:/backup busybox sh -c "cp -a /source/. /backup"
+```
+{: .copy-code}
+
+Create docker compose file for ThingsBoard Edge upgrade process:
+
+```text
+> docker-compose-upgrade.yml && nano docker-compose-upgrade.yml
+```
+{: .copy-code}
+
+Add the following lines to the yml file:
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: on-failure
+    image: "thingsboard/tb-edge-pe:3.9.0EDGEPE"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+    entrypoint: upgrade-tb-edge.sh
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_DB: tb-edge
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - tb-edge-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  tb-edge-data:
+    name: tb-edge-data
+  tb-edge-logs:
+    name: tb-edge-logs
+  tb-edge-postgres-data:
+    name: tb-edge-postgres-data
+```
+{: .copy-code}
+
+Execute the following command to start upgrade process:
+```
+docker compose -f docker-compose-upgrade.yml up
+```
+{: .copy-code}
+
+Once upgrade process successfully completed, exit from the docker-compose shell by this combination:
+```
+Ctrl + C
+```
+
+Execute the following command to stop TB Edge upgrade container:
+```
+docker compose -f docker-compose-upgrade.yml stop
+```
+{: .copy-code}
+
+Modify 'main' docker compose (`docker-compose.yml`) file for ThingsBoard Edge and update version of the image:
+
+```text
+nano docker-compose.yml
+```
+{: .copy-code}
+
+```yml
+version: '3.8'
+services:
+  mytbedge:
+    restart: always
+    image: "thingsboard/tb-edge-pe:3.9.0EDGEPE"
+...
+```
+
+Make sure your image is the set to tb-edge-**pe:3.9.0EDGEPE**.
+
+Execute the following commands to up this docker compose directly:
+```
+docker compose up -d
+docker compose logs -f mytbedge
+```
+{: .copy-code}
+
+
+### Windows {#windows-39}
+
+**NOTE**: These steps are applicable for ThingsBoard Edge 3.8EDGEPE version.
+
+#### ThingsBoard Edge package download
+
+Download ThingsBoard Edge package for Windows: [tb-edge-windows-3.9pe.zip](https://dist.thingsboard.io/tb-edge-windows-3.9pe.zip).
+
+#### ThingsBoard Edge service upgrade
+
+* Stop ThingsBoard Edge service if it is running:
+
+```text
+net stop tb-edge
+```
+{: .copy-code}
+
+* Make a backup of previous ThingsBoard Edge configuration located in *\<ThingsBoard Edge install dir\>\conf* (for example: *C:\tb-edge\conf*).
+
+* Extract ThingsBoard Edge package.
+
+* Compare and merge your old ThingsBoard Edge configuration files (from the backup you made in the previous step) with new ones.
+
+* Finally, run **upgrade.bat** script to upgrade ThingsBoard Edge to the new version.
+
+**NOTE** Scripts listed below should be executed using Administrator Role.
+
+Execute regular upgrade script:
+
+```text
+C:\tb-edge>upgrade.bat --fromVersion=3.8.0
+```
+
+#### Start the service
+
+```text
+net start tb-edge
+```
+{: .copy-code}
 
 ## Upgrading to 3.8EDGEPE {#upgrading-to-38}
 


### PR DESCRIPTION
1. Added new installation configurations (ce and pe):

- for ubuntu:
  - PostgreSQL+Cassandra
  - Kafka
  - Kafka in Docker

- for centos/hrel:
  - PostgreSQL+Cassandra
  - Kafka

- for Docker (Linux or Mac OS)
  - Kafka
  - Kafka+PostgreSQL+Cassandra

2. Corrected style and grammar 
3. Updated upgrade instructions (ce and pe)

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
