### PR TITLE
Added arduino libraries to Raspberry Pi Pico W guide

### DIFF
--- a/_includes/docs/devices-library/blocks/microcontrollers/raspberry-pi-pico-arduino-library-install-block.md
+++ b/_includes/docs/devices-library/blocks/microcontrollers/raspberry-pi-pico-arduino-library-install-block.md
@@ -34,3 +34,4 @@ Port depends on operation system and may be different:
 - for Windows - **COM**X.  
 
 {% assign wifininaInstallationRequired = "true" %}
+{% assign mbedtlsInstallationRequired="true" %}

--- a/_includes/docs/devices-library/blocks/microcontrollers/thingsboard-arduino-library-install-block.md
+++ b/_includes/docs/devices-library/blocks/microcontrollers/thingsboard-arduino-library-install-block.md
@@ -22,7 +22,7 @@ All provided code examples require ThingsBoard Library version {% if wifininaIns
 
 {% if mbedtlsInstallationRequired == "true" %}
 
-Also, for boards, based on ESP8266 chip we should install the "mbedtls" and "arduino-timer" libraries.  
+Also, for boards, based on ESP8266 or RP2040 chip we should install the "mbedtls" and "arduino-timer" libraries.  
 
 {% assign mbedtlsInstallation='
     ===


### PR DESCRIPTION
## PR description

The documentation was updated for Device Library -> Raspberry Pi Pico W. 
If you follow the step-by-step guide, the firmware couldn't compile due to missing libraries. Steps were added to install those libraries in Arduino IDE.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
