### PR TITLE
Remove unused sni settings from certbot configuration

### DIFF
--- a/docs/user-guide/install/aws-marketplace-pe-upgrade-haproxy.md
+++ b/docs/user-guide/install/aws-marketplace-pe-upgrade-haproxy.md
@@ -198,7 +198,6 @@ $ cat <<EOT | sudo tee /usr/local/etc/letsencrypt/cli.ini
 authenticator = standalone
 agree-tos = True
 http-01-port = 8090
-tls-sni-01-port = 8443
 non-interactive = True
 preferred-challenges = http-01
 EOT

--- a/docs/user-guide/install/pe/add-haproxy-rhel.md
+++ b/docs/user-guide/install/pe/add-haproxy-rhel.md
@@ -215,7 +215,6 @@ cat <<EOT | sudo tee /usr/local/etc/letsencrypt/cli.ini
 authenticator = standalone
 agree-tos = True
 http-01-port = 8090
-tls-sni-01-port = 8443
 non-interactive = True
 preferred-challenges = http-01
 EOT


### PR DESCRIPTION
## PR description

The documentation updated because the SNI challenge is outdated and deprecated, no longer supported by letsencrypt. We only use http-01 challenge now, and those parameters confuse users:

> this guide is no longer up to date for centOS 9 (Rocky Linux):
> https://thingsboard.io/docs/user-guide/install/pe/add-haproxy-rhel/
> the sni challenge has been replaced by the DNS or HTTP challenge. Can you update the documentation accordingly?

The updated configuration is already in use in the [Ubuntu deployment guide](https://thingsboard.io/docs/user-guide/install/pe/add-haproxy-ubuntu/#step-7-configure-certbot-with-lets-encrypt). This commit updates the CentOS/AWS guide for consistency.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
