### PR TITLE
fixed port typecasting

### DIFF
--- a/docs/user-guide/resources/firmware/mqtt_firmware_client.py
+++ b/docs/user-guide/resources/firmware/mqtt_firmware_client.py
@@ -42,8 +42,8 @@ def collect_required_data():
     print("="*80, "\n\n", sep="")
     host = input("Please write your ThingsBoard host or leave it blank to use default (localhost): ")
     config["host"] = host if host else "localhost"
-    host = input("Please write your ThingsBoard port or leave it blank to use default (1883): ")
-    config["port"] = host if host else 1883
+    port = input("Please write your ThingsBoard port or leave it blank to use default (1883): ")
+    config["port"] = int(port) if port else 1883
     token = ""
     while not token:
         token = input("Please write accessToken for device: ")


### PR DESCRIPTION
## PR description

The documentation for the MQTT OTA example script has been updated. Previously, custom port was retrieved via **input()** function which returns **str** object, after that paho library checks if the **port <= 0** which throws an exception because it's not possible to compare string with integer. Also, fixed variable names to be consistent.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
