### PR TITLE
Fix k8s repos branch name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,7 @@ collections:
 release:
   branch: release-3.9
   branch_major_next: master
-  ver: 3.9
+  ver: 3.9.0
   ce_ver: 3.9
   ce_tag: v3.9
   ce_full_ver: 3.9.0

--- a/docs/user-guide/install/pe/cluster/aws-monolith-setup.md
+++ b/docs/user-guide/install/pe/cluster/aws-monolith-setup.md
@@ -50,7 +50,7 @@ This guide will help you to set up ThingsBoard in monolith mode in AWS EKS.
 ## Step 1. Clone ThingsBoard PE K8S scripts repository
 
 ```bash
-git clone -b release- {{site.release.ver}} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{site.release.ver}} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/aws/monolith
 ```
 {: .copy-code}


### PR DESCRIPTION
## PR description

The documentation updated for kubernetes deployment guides, part with git clone command. Branch names in github and in code examples were different.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
