### PR TITLE
Update docker monolith upgrade instructions for 3.9.1 release

### DIFF
--- a/docs/user-guide/install/pe/docker-windows.md
+++ b/docs/user-guide/install/pe/docker-windows.md
@@ -114,12 +114,13 @@ If you still rely on Docker Compose as docker-compose (with a hyphen) execute ne
 
 * Update docker-compose.yml - TB image should be the latest version (see [Step 3](#step-3-choose-thingsboard-queue-service))
 
-* Change upgradeversion variable to your **current** ThingsBoard version. For ex., if you are upgrading from 3.6.4:
-
- ```bash
-echo '3.6.4' | sudo tee ~/.mytbpe-data/.upgradeversion
-```
-{: .copy-code}
+* In case you are upgrading to:
+  * 3.9.1 or newer - no additional actions required
+  * 3.9.0 or previous releases - change `upgradeversion` variable to your **current** ThingsBoard version. For ex., if upgrading from 3.6.4:
+    ```bash
+    echo '3.6.4' | sudo tee ~/.mytbpe-data/.upgradeversion
+    ```
+    {: .copy-code}
 
 * Execute the following commands:
 

--- a/docs/user-guide/install/pe/docker.md
+++ b/docs/user-guide/install/pe/docker.md
@@ -104,12 +104,13 @@ If you still rely on Docker Compose as docker-compose (with a hyphen) execute ne
 
 * Update docker-compose.yml - TB image should be the latest version (see [Step 3](#step-3-choose-thingsboard-queue-service))
 
-* Change upgradeversion variable to your **current** ThingsBoard version. For ex., if you are upgrading from 3.6.4:
-
- ```bash
-echo '3.6.4' | sudo tee ~/.mytbpe-data/.upgradeversion
-```
-{: .copy-code}
+* In case you are upgrading to:
+  * 3.9.1 or newer - no additional actions required
+  * 3.9.0 or previous releases - change `upgradeversion` variable to your **current** ThingsBoard version. For ex., if upgrading from 3.6.4:
+    ```bash
+    echo '3.6.4' | sudo tee ~/.mytbpe-data/.upgradeversion
+    ```
+    {: .copy-code}
 
 * Execute the following commands:
 


### PR DESCRIPTION
## PR description

Updated instructions for Docker Monolith PE installs (Linux and Windows) - specify required actions depending on the upgrade version.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
