### PR TITLE
Changed variable for branch name, minor changes

### DIFF
--- a/docs/user-guide/install/cluster/aws-microservices-setup.md
+++ b/docs/user-guide/install/cluster/aws-microservices-setup.md
@@ -87,7 +87,7 @@ We will use Amazon RDS for managed PostgreSQL, Amazon MSK for managed Kafka and 
 ## Step 1. Clone ThingsBoard CE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
 cd thingsboard-ce-k8s/aws/microservices
 ```
 {: .copy-code}

--- a/docs/user-guide/install/cluster/aws-monolith-setup.md
+++ b/docs/user-guide/install/cluster/aws-monolith-setup.md
@@ -47,7 +47,7 @@ K8S will restart the service on another instance. We will use Amazon RDS for man
 ## Step 1. Clone ThingsBoard CE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
 cd thingsboard-ce-k8s/aws/monolith
 ```
 

--- a/docs/user-guide/install/cluster/azure-microservices-setup.md
+++ b/docs/user-guide/install/cluster/azure-microservices-setup.md
@@ -19,7 +19,7 @@ This guide will help you to setup ThingsBoard in microservices mode in Azure AKS
 ## Step 1. Clone ThingsBoard CE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
 cd thingsboard-ce-k8s/azure/microservices
 ```
 {: .copy-code}

--- a/docs/user-guide/install/cluster/azure-monolith-setup.md
+++ b/docs/user-guide/install/cluster/azure-monolith-setup.md
@@ -20,7 +20,7 @@ This guide will help you to setup ThingsBoard in monolith mode in Azure AKS.
 ## Step 1. Clone ThingsBoard CE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
 cd thingsboard-ce-k8s/azure/monolith
 ```
 {: .copy-code}

--- a/docs/user-guide/install/cluster/gcp-microservices-setup.md
+++ b/docs/user-guide/install/cluster/gcp-microservices-setup.md
@@ -20,7 +20,7 @@ This guide will help you to setup ThingsBoard in microservices mode in GKE.
 ## Step 1. Clone ThingsBoard CE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git
 cd thingsboard-ce-k8s/gcp/microservices
 ```
 

--- a/docs/user-guide/install/cluster/gcp-monolith-setup.md
+++ b/docs/user-guide/install/cluster/gcp-monolith-setup.md
@@ -21,7 +21,7 @@ This guide will help you to set up ThingsBoard in monolith mode in GKE.
 Clone the repository and change the working directory to GCP scripts.
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-сe-k8s.git
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-сe-k8s.git
 cd thingsboard-сe-k8s/gcp/monolith
 ```
 {: .copy-code}

--- a/docs/user-guide/install/cluster/minikube-cluster-setup.md
+++ b/docs/user-guide/install/cluster/minikube-cluster-setup.md
@@ -36,7 +36,7 @@ See [**microservices**](/docs/reference/msa/) architecture page for more details
 ## Step 2. Clone ThingsBoard CE Kubernetes scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git --depth 1
 cd thingsboard-ce-k8s/minikube
 ```
 {: .copy-code}

--- a/docs/user-guide/install/cluster/openshift-cluster-setup.md
+++ b/docs/user-guide/install/cluster/openshift-cluster-setup.md
@@ -46,7 +46,7 @@ See [**microservices**](/docs/reference/msa/) architecture page for more details
 ## Step 2. Clone ThingsBoard CE Kubernetes scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-ce-k8s.git --depth 1
 cd thingsboard-ce-k8s/openshift
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/aws-microservices-setup.md
+++ b/docs/user-guide/install/pe/cluster/aws-microservices-setup.md
@@ -92,7 +92,7 @@ This guide will help you to setup ThingsBoard in microservices mode in AWS EKS.
 ## Step 1. Clone ThingsBoard PE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/aws/microservices
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/aws-monolith-setup.md
+++ b/docs/user-guide/install/pe/cluster/aws-monolith-setup.md
@@ -50,7 +50,7 @@ This guide will help you to set up ThingsBoard in monolith mode in AWS EKS.
 ## Step 1. Clone ThingsBoard PE K8S scripts repository
 
 ```bash
-git clone -b release- {{site.release.ver}} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/aws/monolith
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/azure-microservices-setup.md
+++ b/docs/user-guide/install/pe/cluster/azure-microservices-setup.md
@@ -23,7 +23,7 @@ This guide will help you to setup ThingsBoard in microservices mode in Azure AKS
 ## Step 1. Clone ThingsBoard PE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/azure/microservices
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/azure-monolith-setup.md
+++ b/docs/user-guide/install/pe/cluster/azure-monolith-setup.md
@@ -24,7 +24,7 @@ This guide will help you to setup ThingsBoard in monolith mode in Azure AKS.
 ## Step 1. Clone ThingsBoard PE K8S scripts repository
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/azure/monolith
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/gcp-microservices-setup.md
+++ b/docs/user-guide/install/pe/cluster/gcp-microservices-setup.md
@@ -26,7 +26,7 @@ This guide will help you to set up ThingsBoard in microservices mode in GKE.
 Clone the repository and change the working directory to GCP scripts.
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/gcp/microservices
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/gcp-monolith-setup.md
+++ b/docs/user-guide/install/pe/cluster/gcp-monolith-setup.md
@@ -28,7 +28,7 @@ This guide will help you to set up ThingsBoard in monolith mode using [Google Ku
 Clone the repository and change the working directory to GCP scripts.
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/gcp/monolith
 ```
 {: .copy-code}

--- a/docs/user-guide/install/pe/cluster/minikube-cluster-setup.md
+++ b/docs/user-guide/install/pe/cluster/minikube-cluster-setup.md
@@ -42,7 +42,7 @@ See [**microservices**](/docs/reference/msa/) architecture page for more details
 ## Step 2. Clone ThingsBoard PE Kubernetes scripts
 
 ```bash
-git clone -b release-{{ site.release.ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
+git clone -b release-{{ site.release.ce_full_ver }} https://github.com/thingsboard/thingsboard-pe-k8s.git --depth 1
 cd thingsboard-pe-k8s/minikube
 ```
 {: .copy-code}


### PR DESCRIPTION
## PR description

The documentation has been updated for k8s installation guides since thingsboard-pe-k8s now have different naming for release branches. Also fixed excess space for aws-monolith guide. 

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
