### PR TITLE
Update of upgrade instructions Windows

### DIFF
--- a/docs/user-guide/install/pe/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/upgrade-instructions.md
@@ -332,7 +332,7 @@ These upgrade steps are applicable for ThingsBoard version 3.9PE. In order to up
 
 #### ThingsBoard PE package download
 
-Download and extract ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-3.9.1pe.exe](https://dist.thingsboard.io/thingsboard-windows-3.9.1pe.zip).
+Download and extract ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-3.9.1pe.zip](https://dist.thingsboard.io/thingsboard-windows-3.9.1pe.zip).
 
 #### ThingsBoard PE service upgrade
 
@@ -1581,7 +1581,7 @@ These upgrade steps are applicable for the latest ThingsBoard Community Edition 
 
 #### ThingsBoard PE package download
 
-Download ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-{{ site.release.pe_ver }}.exe](https://dist.thingsboard.io/thingsboard-windows-setup-{{ site.release.pe_ver }}.exe).
+Download and extract ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-{{ site.release.pe_ver }}.zip](https://dist.thingsboard.io/thingsboard-windows-setup-{{ site.release.pe_ver }}.zip).
 
 #### ThingsBoard PE service upgrade
 
@@ -1593,7 +1593,7 @@ net stop thingsboard
 {: .copy-code}
 
 * Make a backup of previous ThingsBoard CE configuration located in \<ThingsBoard install dir\>\conf (for ex. C:\thingsboard\conf).
-* Run installation package **thingsboard-windows-setup-{{ site.release.pe_ver }}.exe**.
+* Copy content of the **thingsboard-windows-setup-{{ site.release.pe_ver }}.zip** to the same location.
 * Compare and merge your old ThingsBoard configuration files (from the backup you made in the first step) with new ones.
 * Configure Professional Edition license key as described [here](/docs/user-guide/install/pe/windows/#step-3-obtain-and-configure-license-key).
 * Finally, run **upgrade.bat** script to upgrade ThingsBoard to the new version.


### PR DESCRIPTION
fix broken link for ce-to-pe upgrade
clarify upgrade actions

## PR description

The documentation was updated for Windows 3.9.1 PE and CE to PE upgrade instructions.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
