### PR TITLE
Fix upgrade instructions package versions in 3.9.1 CE guide

### DIFF
--- a/docs/user-guide/install/upgrade-instructions.md
+++ b/docs/user-guide/install/upgrade-instructions.md
@@ -175,8 +175,8 @@ sudo service thingsboard stop
 {: .copy-code}
 
 {% capture tabspec %}thingsboard-installation-3-9-1
-thingsboard-installation-3-9-1-ubuntu,Ubuntu,shell,resources/3.9/thingsboard-ubuntu-installation.sh,/docs/user-guide/install/resources/3.9.1/thingsboard-ubuntu-installation.sh
-thingsboard-installation-3-9-1-centos,CentOS,shell,resources/3.9/thingsboard-centos-installation.sh,/docs/user-guide/install/resources/3.9.1/thingsboard-centos-installation.sh{% endcapture %}
+thingsboard-installation-3-9-1-ubuntu,Ubuntu,shell,resources/3.9.1/thingsboard-ubuntu-installation.sh,/docs/user-guide/install/resources/3.9.1/thingsboard-ubuntu-installation.sh
+thingsboard-installation-3-9-1-centos,CentOS,shell,resources/3.9.1/thingsboard-centos-installation.sh,/docs/user-guide/install/resources/3.9.1/thingsboard-centos-installation.sh{% endcapture %}
 {% include tabs.html %}
 
 {% capture difference %}


### PR DESCRIPTION
## PR description

Fix upgrade instructions package versions from 3.9 to 3.9.1 in the 3.9.1 CE guide section

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
