### PR TITLE
Fixed color for device library article pages

### DIFF
--- a/_layouts/devices-library-article.liquid
+++ b/_layouts/devices-library-article.liquid
@@ -40,6 +40,9 @@
 {% endfor %}
 {% if siteData[foundTOC].notitle == "true" or page.notitle == "true" %}{% assign notitle = "true" %}{% endif %}
 
+{% assign foundProduct = site.data.products | where: "tag", docsTag %}
+{% assign productInfo = foundProduct[0] %}
+
 <!Doctype html>
 <html id="docs" class="{{ siteData[foundTOC].bigheader }} {{ productInfo.tag }}">
 


### PR DESCRIPTION
## PR description

Before fix:
![image](https://github.com/user-attachments/assets/9c66ec43-7db6-414e-acd2-050d35a7bbbf)
After fix:
![image](https://github.com/user-attachments/assets/6d0f11fa-92c9-4eb7-bd0a-ca698252da02)


## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
