### PR TITLE
Mqtt retransmission doc

### DIFF
--- a/_includes/docs/pe/user-guide/integrations/mqtt.md
+++ b/_includes/docs/pe/user-guide/integrations/mqtt.md
@@ -333,6 +333,30 @@ Go to the **Devices** page and find *rpcReceived* telemetry value is "*OK*" on t
 ![image](/images/user-guide/integrations/mqtt/mqtt-rpc-device-1-paas.png)
 {% endif %}
 
+### MQTT retransmission mechanism
+
+The MQTT integration uses ThingsBoard's internal MQTT client, which includes a retransmission mechanism to improve reliability for certain message types that require acknowledgment.
+This mechanism applies specifically to the following MQTT message types: PUBLISH (only for QoS 1 or 2), SUBSCRIBE, UNSUBSCRIBE, PUBREL (only for QoS 2).
+
+When one of these messages is sent, the client waits for an acknowledgment within a configurable delay period.
+If the acknowledgment is not received, the message is retransmitted.
+The delay between retransmissions follows an exponential backoff strategy, starting from an initial delay and doubling with each attempt.
+A configurable jitter factor is applied to introduce randomness to the delay, helping to prevent synchronized retries.
+
+By default, the client performs up to three retransmission attempts in addition to the original send.
+These retries are scheduled at approximately 5,000 ms, 10,000 ms, and 20,000 ms, each adjusted by ±15% jitter.
+If no acknowledgment is received after the final attempt, the message is considered undeliverable and is dropped.
+
+These parameters can be adjusted in the thingsboard.yml configuration file. Note that changes here affect all MQTT clients across the platform—not just this specific integration:
+```yaml
+mqtt:
+  client:
+    retransmission:
+      max_attempts: "${TB_MQTT_CLIENT_RETRANSMISSION_MAX_ATTEMPTS:3}"
+      initial_delay_millis: "${TB_MQTT_CLIENT_RETRANSMISSION_INITIAL_DELAY_MILLIS:5000}"
+      jitter_factor: "${TB_MQTT_CLIENT_RETRANSMISSION_JITTER_FACTOR:0.15}"
+```
+
 ## Video tutorials
 
 ### Setting up MQTT Integration

--- a/_includes/docs/pe/user-guide/integrations/mqtt.md
+++ b/_includes/docs/pe/user-guide/integrations/mqtt.md
@@ -335,27 +335,15 @@ Go to the **Devices** page and find *rpcReceived* telemetry value is "*OK*" on t
 
 ### MQTT retransmission mechanism
 
-The MQTT integration uses ThingsBoard's internal MQTT client, which includes a retransmission mechanism to improve reliability for certain message types that require acknowledgment.
-This mechanism applies specifically to the following MQTT message types: PUBLISH (only for QoS 1 or 2), SUBSCRIBE, UNSUBSCRIBE, PUBREL (only for QoS 2).
+The MQTT integration uses ThingsBoard's internal MQTT client.
 
-When one of these messages is sent, the client waits for an acknowledgment within a configurable delay period.
-If the acknowledgment is not received, the message is retransmitted.
-The delay between retransmissions follows an exponential backoff strategy, starting from an initial delay and doubling with each attempt.
-A configurable jitter factor is applied to introduce randomness to the delay, helping to prevent synchronized retries.
+{% if docsPrefix contains "paas" %}
+{% include docs/user-guide/mqtt-retransmission-mechanism.md show-yml-config=false %}
+{% else %}
+{% include docs/user-guide/mqtt-retransmission-mechanism.md show-yml-config=true %}
+{% endif %}
 
-By default, the client performs up to three retransmission attempts in addition to the original send.
-These retries are scheduled at approximately 5,000 ms, 10,000 ms, and 20,000 ms, each adjusted by ±15% jitter.
-If no acknowledgment is received after the final attempt, the message is considered undeliverable and is dropped.
-
-These parameters can be adjusted in the thingsboard.yml configuration file. Note that changes here affect all MQTT clients across the platform—not just this specific integration:
-```yaml
-mqtt:
-  client:
-    retransmission:
-      max_attempts: "${TB_MQTT_CLIENT_RETRANSMISSION_MAX_ATTEMPTS:3}"
-      initial_delay_millis: "${TB_MQTT_CLIENT_RETRANSMISSION_INITIAL_DELAY_MILLIS:5000}"
-      jitter_factor: "${TB_MQTT_CLIENT_RETRANSMISSION_JITTER_FACTOR:0.15}"
-```
+When the MQTT message is dropped, the corresponding rule engine message is routed via **Failure** chain with the appropriate exception message.
 
 ## Video tutorials
 

--- a/_includes/docs/user-guide/mqtt-retransmission-mechanism.md
+++ b/_includes/docs/user-guide/mqtt-retransmission-mechanism.md
@@ -1,0 +1,26 @@
+ThingsBoard's internal MQTT client includes a retransmission mechanism designed to improve reliability for message types that require acknowledgment.  
+This mechanism applies specifically to the following MQTT message types:
+- **PUBLISH** (only for QoS 1 or 2)
+- **SUBSCRIBE**
+- **UNSUBSCRIBE**
+- **PUBREL** (only for QoS 2)
+
+When one of these messages is sent, the client waits for an acknowledgment within a configurable delay period.  
+If no acknowledgment is received, the message is retransmitted. The delay between retransmissions follows an **exponential backoff** strategy, starting from an initial delay and doubling with each attempt.  
+A **jitter factor** introduces random variance into the delay to help prevent synchronized retries.
+
+For example, if the retransmission configuration is set to **three attempts**, with an **initial delay of 5,000 ms** and a **jitter factor of 0.15**, the retransmission attempts would be scheduled at approximately **5,000 ms**, **10,000 ms**, and **20,000 ms**, each adjusted by ±15% jitter.  
+If no acknowledgment is received after the final attempt, the system waits through the next scheduled delay—based on exponential backoff with jitter—before finally considering the message **undeliverable and dropping it**.
+
+{% if include.show-yml-config == true %}
+You can configure retransmission parameters globally in the `thingsboard.yml` file. These settings affect **all MQTT clients** on the platform:
+
+```yaml
+mqtt:
+  client:
+    retransmission:
+      max_attempts: "${TB_MQTT_CLIENT_RETRANSMISSION_MAX_ATTEMPTS:3}"
+      initial_delay_millis: "${TB_MQTT_CLIENT_RETRANSMISSION_INITIAL_DELAY_MILLIS:5000}"
+      jitter_factor: "${TB_MQTT_CLIENT_RETRANSMISSION_JITTER_FACTOR:0.15}"
+```
+{% endif %}

--- a/_includes/docs/user-guide/rule-engine-2-0/ce-external-nodes.md
+++ b/_includes/docs/user-guide/rule-engine-2-0/ce-external-nodes.md
@@ -286,6 +286,31 @@ If required, Rule Chain can be configured to use chain of Transformation Nodes f
 In case of successful message publishing, original Message will be passed to the next nodes via **Success** chain, 
 otherwise **Failure** chain is used.
 
+**MQTT retransmission mechanism**
+
+The MQTT Node uses ThingsBoard's internal MQTT client, which includes a retransmission mechanism to improve reliability for certain message types that require acknowledgment. 
+This mechanism applies specifically to the following MQTT message types: PUBLISH (only for QoS 1 or 2), SUBSCRIBE, UNSUBSCRIBE, PUBREL (only for QoS 2).
+
+When one of these messages is sent, the client waits for an acknowledgment within a configurable delay period. 
+If the acknowledgment is not received, the message is retransmitted. 
+The delay between retransmissions follows an exponential backoff strategy, starting from an initial delay and doubling with each attempt. 
+A configurable jitter factor is applied to introduce randomness to the delay, helping to prevent synchronized retries.
+
+By default, the client performs up to three retransmission attempts in addition to the original send. 
+These retries are scheduled at approximately 5,000 ms, 10,000 ms, and 20,000 ms, each adjusted by ±15% jitter. 
+If no acknowledgment is received after the final attempt, the message is considered undeliverable and is dropped. 
+When this happens, the corresponding Rule Engine message is routed via the **Failure** chain, along with an appropriate exception message.
+
+These parameters can be adjusted in the thingsboard.yml configuration file. Note that changes here affect all MQTT clients across the platform—not just this specific rule node:
+```yaml
+mqtt:
+  client:
+    retransmission:
+      max_attempts: "${TB_MQTT_CLIENT_RETRANSMISSION_MAX_ATTEMPTS:3}"
+      initial_delay_millis: "${TB_MQTT_CLIENT_RETRANSMISSION_INITIAL_DELAY_MILLIS:5000}"
+      jitter_factor: "${TB_MQTT_CLIENT_RETRANSMISSION_JITTER_FACTOR:0.15}"
+```
+
 <br>
 
 ## Azure IoT Hub Node

--- a/_includes/docs/user-guide/rule-engine-2-0/ce-external-nodes.md
+++ b/_includes/docs/user-guide/rule-engine-2-0/ce-external-nodes.md
@@ -288,28 +288,15 @@ otherwise **Failure** chain is used.
 
 **MQTT retransmission mechanism**
 
-The MQTT Node uses ThingsBoard's internal MQTT client, which includes a retransmission mechanism to improve reliability for certain message types that require acknowledgment. 
-This mechanism applies specifically to the following MQTT message types: PUBLISH (only for QoS 1 or 2), SUBSCRIBE, UNSUBSCRIBE, PUBREL (only for QoS 2).
+The MQTT node uses ThingsBoard's internal MQTT client.
 
-When one of these messages is sent, the client waits for an acknowledgment within a configurable delay period. 
-If the acknowledgment is not received, the message is retransmitted. 
-The delay between retransmissions follows an exponential backoff strategy, starting from an initial delay and doubling with each attempt. 
-A configurable jitter factor is applied to introduce randomness to the delay, helping to prevent synchronized retries.
+{% if docsPrefix contains "paas" %}
+{% include docs/user-guide/mqtt-retransmission-mechanism.md show-yml-config=false %}
+{% else %}
+{% include docs/user-guide/mqtt-retransmission-mechanism.md show-yml-config=true %}
+{% endif %}
 
-By default, the client performs up to three retransmission attempts in addition to the original send. 
-These retries are scheduled at approximately 5,000 ms, 10,000 ms, and 20,000 ms, each adjusted by ±15% jitter. 
-If no acknowledgment is received after the final attempt, the message is considered undeliverable and is dropped. 
-When this happens, the corresponding Rule Engine message is routed via the **Failure** chain, along with an appropriate exception message.
-
-These parameters can be adjusted in the thingsboard.yml configuration file. Note that changes here affect all MQTT clients across the platform—not just this specific rule node:
-```yaml
-mqtt:
-  client:
-    retransmission:
-      max_attempts: "${TB_MQTT_CLIENT_RETRANSMISSION_MAX_ATTEMPTS:3}"
-      initial_delay_millis: "${TB_MQTT_CLIENT_RETRANSMISSION_INITIAL_DELAY_MILLIS:5000}"
-      jitter_factor: "${TB_MQTT_CLIENT_RETRANSMISSION_JITTER_FACTOR:0.15}"
-```
+When the message is dropped, the corresponding rule engine message is routed via **Failure** chain with the appropriate exception message.
 
 <br>
 


### PR DESCRIPTION
## PR description

The documentation updated for MQTT integration and MQT node doc. Now includes explanation of how MQTT retransmission mechanism works.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
