### PR TITLE
Fix build from source guide

### DIFF
--- a/docs/user-guide/install/building-from-source.md
+++ b/docs/user-guide/install/building-from-source.md
@@ -19,7 +19,7 @@ This section contains installation instructions for build tools.
 
 ### Java
 
-ThingsBoard is build using Java 11. You can use [following instructions](/docs/user-guide/install/linux#java) to install Java 11.
+ThingsBoard is built using Java 17. You can use [following instructions](/docs/user-guide/install/ubuntu/#step-1-install-java-17-openjdk) to install Java 17.
 
 ### Maven
 
@@ -30,15 +30,15 @@ A,Ubuntu,shell,resources/maven-ubuntu-installation.sh,/docs/user-guide/install/r
 B,CentOS,shell,resources/maven-centos-installation.sh,/docs/user-guide/install/resources/maven-centos-installation.sh{% endcapture %}
 {% include tabs.html %}
 
-**Please note** that maven installation may set Java 7 as a default JVM on certain Linux machines. 
-Use java installation [instructions](#java) to fix this. 
+**Please note** that Maven installation may set Java 7 as a default JVM on certain Linux machines. 
+Use Java installation [instructions](#java) to fix this. 
 
 ## Source code
 
 {% capture windows_line_endings %}
 **NOTE: Building Docker image on Windows machine**
 
-To build Docker image certain scripts, configuration files and sources what will be a part of the Docker image must have **LF** line endings.
+To build Docker image, certain scripts, configuration files and sources that will be a part of the Docker image must have **LF** line endings.
 So before cloning the repo set to _input_ the Git [core.autocrlf](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf) configuration option.
 
 For example, to set *core.autocrlf* globally:
@@ -51,21 +51,21 @@ You can clone source code of the project from the official [github repo](https:/
 
 ```bash
 # checkout latest release branch
-git clone -b {{ site.release.branch }} git@github.com:thingsboard/thingsboard.git --depth 1
+git clone -b {{ site.release.branch }} https://github.com/thingsboard/thingsboard.git --depth 1
 cd thingsboard
 ```
 {: .copy-code}
 
 ## Build
 
-Run the following command from the thingsboard folder to build the project:
+Run the following command from the ThingsBoard folder to build the project:
 
 ```bash
 mvn clean install -DskipTests
 ```
 {: .copy-code}
 
-## Build local docker images
+## Build local Docker images
 
 {% include templates/warn-banner.md content=windows_line_endings %}
 
@@ -87,11 +87,11 @@ application/target
 
 ## Running tests
 
-We are using [docker](https://docs.docker.com/engine/install/) and [docker-compose](https://docs.docker.com/compose/install/) to run all kind of integration and [black-box tests](https://github.com/thingsboard/thingsboard/tree/master/msa/black-box-tests).
+We are using [Docker](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/) to run all kinds of integration and [black-box tests](https://github.com/thingsboard/thingsboard/tree/master/msa/black-box-tests).
 
 Please, manage [Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user) to run tests properly.
 
-Master and release branches is already tested, so you can skip tests and avoid installing docker as well.
+Master and release branches are already tested, so you can skip tests and avoid installing Docker as well.
 
 Run all unit and integration tests:
 
@@ -106,7 +106,7 @@ Estimated time is about 1 hour on AMD Ryzen 5 3600 (6-cores), 32GB DDR4, fancy S
 
 ## Tips and tricks
 
-Thingsboard is quite easy to build from sources on a brand-new clear environment.
+ThingsBoard is quite easy to build from sources on a brand-new clear environment.
 
 Here are some tips and tricks to boost build experience: 
 
@@ -128,7 +128,7 @@ Here are some tips and tricks to boost build experience:
   ```
   {: .copy-code}
 
-- build in parallel, format headers, build docker images
+- build in parallel, format headers, build Docker images
   ```bash
   mvn -T 0.8C license:format clean install -DskipTests -Ddockerfile.skip=false
   ```


### PR DESCRIPTION
## PR description

- Updated the Java version requirement from 11 to 17 and fixed link.
- Changed Git clone command to HTTPS: Replaced the SSH-based clone URL because cloning via SSH can fail due to missing public key access (Permission denied (publickey)). Users outside the organization may not be able to clone the repository via SSH.
- Other general improvements and cleanup.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
