### PR TITLE
Update instructions for cassandra 5 support

### DIFF
--- a/_includes/templates/install/cassandra-rhel-install.md
+++ b/_includes/templates/install/cassandra-rhel-install.md
@@ -1,45 +1,62 @@
-Create and edit the Cassandra repository file:
+The following commands will install Apache Cassandra and its command-line tools:
 
 ```bash
-sudo nano /etc/yum.repos.d/cassandra.repo
-```
-{: .copy-code}
-
-Paste the following content into the file:
-
-```ini
+# Import GPG key
+sudo rpm --import https://downloads.apache.org/cassandra/KEYS 
+# Add Cassandra repository
+sudo tee /etc/yum.repos.d/cassandra.repo > /dev/null <<EOF
 [cassandra]
 name=Apache Cassandra
 baseurl=https://redhat.cassandra.apache.org/50x/
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://downloads.apache.org/cassandra/KEYS
-```
-{: .copy-code}
+EOF
 
-The following commands will install Apache Cassandra and its command-line tools; confirm GPG key imports if prompted:
-
-```bash
 # Install packages
-sudo dnf update
-sudo dnf install cassandra cassandra-tools
+sudo dnf -y update
+sudo dnf -y install cassandra cassandra-tools chkconfig
 # Start service
-sudo systemctl daemon-reload
-sudo service cassandra start
-# Optional: Configure Cassandra to start on boot
-sudo dnf install chkconfig
+sudo systemctl daemon-reexec
+sudo systemctl start cassandra.service
+# Configure Cassandra to start on boot
 sudo chkconfig cassandra on
 ```
 {: .copy-code}
 
-To verify that Cassandra is running, check the node status:
+To verify that Cassandra is running correctly, use the following commands to check both the node status and the system service state:
 
 ```bash
 nodetool status
+sudo systemctl status cassandra.service 
 ```
 {: .copy-code}
-The status column in the output should report `UN` which stands for "Up/Normal"; you may need to wait a few moments for Cassandra to initialize.
+
+The status column in the output should report `UN` which stands for "Up/Normal"; you may need to wait a few moments for Cassandra to initialize. Example output:
+
+```
+$ nodetool status
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack 
+UN  127.0.0.1  136.29 KiB  16      100.0%            60ae50fd-8914-44a1-a397-b716b7d4b37c  rack1
+
+$ sudo systemctl status cassandra.service 
+● cassandra.service - LSB: distributed storage system for structured data
+     Loaded: loaded (/etc/rc.d/init.d/cassandra; generated)
+     Active: active (running) since Thu 2025-04-24 12:22:11 UTC; 11min ago
+       Docs: man:systemd-sysv-generator(8)
+    Process: 34716 ExecStart=/etc/rc.d/init.d/cassandra start (code=exited, status=0/SUCCESS)
+   Main PID: 34819 (java)
+      Tasks: 62 (limit: 50538)
+     Memory: 4.3G
+        CPU: 17.792s
+     CGroup: /system.slice/cassandra.service
+             └─34819 /usr/lib/jvm/java-17-openjdk-17.0.14.0.7-2.el9.x86_64/bin/java -ea -da:net.openhft... -XX:+UseThreadPriorities -XX:+HeapDumpOnOutOfMemoryError -Xss256k -XX:+AlwaysPreTo>
+...
+```
 
 You can use Astra DB Cloud instead of installing your own Cassandra.
 See how to [connect ThingsBoard to Astra DB](/docs/user-guide/install/pe/cassandra-cloud-astra-db/)
-

--- a/_includes/templates/install/cassandra-ubuntu-install.md
+++ b/_includes/templates/install/cassandra-ubuntu-install.md
@@ -2,22 +2,46 @@ The following commands will install Apache Cassandra and its command-line tools:
 
 ```bash
 # Add Cassandra repository
-echo "deb [signed-by=/etc/apt/keyrings/apache-cassandra.asc] https://debian.cassandra.apache.org 50x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+echo "deb [signed-by=/etc/apt/keyrings/apache-cassandra.asc] https://debian.cassandra.apache.org 50x main" | sudo tee /etc/apt/sources.list.d/cassandra.sources.list
 sudo curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
 sudo apt-get update
-
-## Cassandra installation
-sudo apt-get install cassandra cassandra-tools
+# Cassandra installation
+sudo apt-get install -y cassandra cassandra-tools
 ```
 {: .copy-code}
 
-To verify that Cassandra is running, check the node status:
+To verify that Cassandra is running correctly, use the following commands to check both the node status and the system service state:
 
 ```bash
 nodetool status
+sudo systemctl status cassandra.service 
 ```
 {: .copy-code}
-The status column in the output should report `UN` which stands for "Up/Normal".
+
+The status column in the output should report `UN` which stands for "Up/Normal"; you may need to wait a few moments for Cassandra to initialize. Example output:
+
+```
+$ nodetool status
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address    Load        Tokens  Owns (effective)  Host ID                               Rack 
+UN  127.0.0.1  114.67 KiB  16      100.0%            b8e1bd83-5280-4e48-8b17-a4548eec583b  rack1
+
+$ sudo systemctl status cassandra.service 
+● cassandra.service - LSB: distributed storage system for structured data
+     Loaded: loaded (/etc/init.d/cassandra; generated)
+     Active: active (running) since Thu 2025-04-24 14:04:35 UTC; 43s ago
+       Docs: man:systemd-sysv-generator(8)
+    Process: 9415 ExecStart=/etc/init.d/cassandra start (code=exited, status=0/SUCCESS)
+      Tasks: 61 (limit: 9439)
+     Memory: 4.3G (peak: 4.3G)
+        CPU: 14.470s
+     CGroup: /system.slice/cassandra.service
+             └─9553 /usr/bin/java -ea -da:net.openhft... -XX:+UseThreadPriorities -XX:+HeapDumpOnOutOfMemoryError -Xss256k -XX:+AlwaysPreTouch -XX:+UseTLAB -XX:+ResizeTLAB -XX:+UseNUMA -XX:>
+...
+```
 
 You can use Astra DB Cloud instead of installing your own Cassandra.
 See how to [connect ThingsBoard to Astra DB](/docs/user-guide/install/pe/cassandra-cloud-astra-db/)


### PR DESCRIPTION
## PR description

Update Cassandra installation instructions to use Cassandra 5.x for RHEL and Ubuntu.
Tested on Ubuntu 24.04 and CentOS 9 Stream with Thingsboard 4.0 CE

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
