### PR TITLE
Fixed wrong versions in Notes for 4.0.1 upgrade

### DIFF
--- a/docs/user-guide/install/pe/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/upgrade-instructions.md
@@ -295,7 +295,7 @@ Do nothing, postgresql is already running.
 {% capture difference %}
 **NOTE:**
 <br>
-These upgrade steps are applicable for ThingsBoard version 3.9.xPE. In order to upgrade to 4.0.1PE you need to [**upgrade to 3.9.1PE first**](/docs/user-guide/install/pe/upgrade-instructions/#ubuntucentos-391).
+These upgrade steps are applicable for ThingsBoard version 4.0PE. In order to upgrade to 4.0.1PE you need to [**upgrade to 4.0PE first**](/docs/user-guide/install/pe/upgrade-instructions/#ubuntucentos-40).
 {% endcapture %}
 {% include templates/info-banner.md content=difference %}
 
@@ -349,7 +349,7 @@ sudo service thingsboard start
 {% capture difference %}
 **NOTE:**
 <br>
-These upgrade steps are applicable for ThingsBoard version 3.9.xPE. In order to upgrade to 4.0.1PE you need to [**upgrade to 3.9.1PE first**](/docs/user-guide/install/pe/upgrade-instructions/#windows-391).
+These upgrade steps are applicable for ThingsBoard version 4.0.0PE. In order to upgrade to 4.0.1PE you need to [**upgrade to 4.0PE first**](/docs/user-guide/install/pe/upgrade-instructions/#windows-40).
 {% endcapture %}
 {% include templates/info-banner.md content=difference %}
 

--- a/docs/user-guide/install/upgrade-instructions.md
+++ b/docs/user-guide/install/upgrade-instructions.md
@@ -176,7 +176,7 @@ description: ThingsBoard IoT platform upgrade instructions
 {% capture difference %}
 **NOTE:**
 <br>
-These upgrade steps are applicable for ThingsBoard version 3.9.x. In order to upgrade to 4.0.1 you need to [**upgrade to 3.9.x first**](/docs/user-guide/install/upgrade-instructions/#ubuntucentos-391).
+These upgrade steps are applicable for ThingsBoard version 4.0. In order to upgrade to 4.0.1 you need to [**upgrade to 4.0 first**](/docs/user-guide/install/upgrade-instructions/#ubuntucentos-40).
 {% endcapture %}
 {% include templates/info-banner.md content=difference %}
 
@@ -227,7 +227,7 @@ sudo service thingsboard start
 {% capture difference %}
 **NOTE:**
 <br>
-These upgrade steps are applicable for ThingsBoard version 3.9.x. In order to upgrade to 4.0.1 you need to [**upgrade to 3.9.x first**](/docs/user-guide/install/upgrade-instructions/#windows-39).
+These upgrade steps are applicable for ThingsBoard version 4.0. In order to upgrade to 4.0.1 you need to [**upgrade to 4.0 first**](/docs/user-guide/install/upgrade-instructions/#windows-40).
 {% endcapture %}
 {% include templates/info-banner.md content=difference %}
 


### PR DESCRIPTION
## PR description

The documentation has been updated for Thingsboard CE/PE upgrade instructions. The previous version contained a typo in the Notes and required an incompatible version for upgrade (3.9.x -> 4.0.1). 

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
