### PR TITLE
Add Valkey reference where Redis mentioned

### DIFF
--- a/_includes/docs/pe/user-guide/install/coap-transport-config.md
+++ b/_includes/docs/pe/user-guide/install/coap-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/pe/user-guide/install/core-rule-engine-config.md
+++ b/_includes/docs/pe/user-guide/install/core-rule-engine-config.md
@@ -2393,7 +2393,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/pe/user-guide/install/http-transport-config.md
+++ b/_includes/docs/pe/user-guide/install/http-transport-config.md
@@ -211,7 +211,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/pe/user-guide/install/ie-executor-config.md
+++ b/_includes/docs/pe/user-guide/install/ie-executor-config.md
@@ -1050,7 +1050,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/pe/user-guide/install/lwm2m-transport-config.md
+++ b/_includes/docs/pe/user-guide/install/lwm2m-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/pe/user-guide/install/mqtt-transport-config.md
+++ b/_includes/docs/pe/user-guide/install/mqtt-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/pe/user-guide/install/snmp-transport-config.md
+++ b/_includes/docs/pe/user-guide/install/snmp-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/reference/msa.md
+++ b/_includes/docs/reference/msa.md
@@ -99,10 +99,15 @@ The main idea is to sacrifice small performance/latency penalties in favor of pe
 [Apache Kafka](https://kafka.apache.org/) is an open-source stream-processing software platform. ThingsBoard uses Kafka to persist incoming telemetry from HTTP/MQTT/CoAP transpots 
 until it is processed by the rule engine. ThingsBoard also uses Kafka for some API calls between micro-services.
 
-### Redis
+### Cache database
 
-[Redis](https://redis.io/) is an open-source (BSD licensed), in-memory data structure store used by ThingsBoard for caching. 
 ThingsBoard caches assets, entity views, devices, device credentials, device sessions and entity relations.
+
+##### Redis
+[Redis](https://redis.io/) is source-available (under [RSALv2](https://redis.io/legal/rsalv2-agreement/) and [SSPLv1](https://redis.io/legal/server-side-public-license-sspl/)) in-memory data structure store used by ThingsBoard for caching.
+
+##### Valkey
+[Valkey](https://valkey.io/) is an open-source (BSD licensed), in-memory data structure store that could be used as a drop-in replacement for Redis.
 
 ### Zookeeper
 

--- a/_includes/docs/user-guide/attributes.md
+++ b/_includes/docs/user-guide/attributes.md
@@ -304,7 +304,7 @@ You can achieve higher performance with Attributes Cache enabled (see <b>cache.a
 
 Having attributes cache enabled ThingsBoard will load the specific attribute from the database only once, all subsequent requests to the attribute will be loaded from the faster cache connection.
 
-**NOTE:** If you are using Redis cache, make sure that you change <b>maxmemory-policy</b> to <b>allkeys-random</b> to prevent Redis from filling up all available memory.
+**NOTE:** If you are using Redis or Valkey cache, make sure that you change <b>maxmemory-policy</b> to <b>allkeys-random</b> to prevent the service from filling up all available memory.
 
 {% endunless %}
 

--- a/_includes/docs/user-guide/install/coap-transport-config.md
+++ b/_includes/docs/user-guide/install/coap-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/user-guide/install/core-rule-engine-config.md
+++ b/_includes/docs/user-guide/install/core-rule-engine-config.md
@@ -2039,7 +2039,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/user-guide/install/http-transport-config.md
+++ b/_includes/docs/user-guide/install/http-transport-config.md
@@ -211,7 +211,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/user-guide/install/lwm2m-transport-config.md
+++ b/_includes/docs/user-guide/install/lwm2m-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/user-guide/install/mqtt-transport-config.md
+++ b/_includes/docs/user-guide/install/mqtt-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/user-guide/install/snmp-transport-config.md
+++ b/_includes/docs/user-guide/install/snmp-transport-config.md
@@ -145,7 +145,7 @@
 </table>
 
 
-##  Redis configuration parameters
+##  Redis/Valkey configuration parameters
 
 <table>
 	<thead>

--- a/_includes/docs/user-guide/troubleshooting.md
+++ b/_includes/docs/user-guide/troubleshooting.md
@@ -54,14 +54,13 @@ After this you can find the following messages in your [logs](#logs):
 2021-03-24 17:01:21,028 [tb-rule-engine-consumer-24-thread-3] INFO  o.t.s.s.q.TbMsgPackProcessingContext - [Main][3f6debf0-8cc0-11eb-bcd9-d343878c0c7f] execution count: 1. [RuleChain: Thermostat|RuleNode: Message Type Switch(3f6debf0-8cc0-11eb-bcd9-d343878c0c7f)]
 ```
 
-### Clearing Redis Cache
+### Clearing Redis/Valkey Cache
 
-**Note:** This can be used only if Redis is selected as a cache.
+**Note:** This can be used only if Redis or Valkey is selected as a cache.
 
-It is possible that the data inside the cache somehow got corrupted. Regardless of the reason, it is always safe to clear cache, ThingsBoard will just refill it at the runtime.
-To clear Redis cache you need to log into the server/container/pod with Redis on it and call <code>redis-cli FLUSHALL</code> command. To clear the cache in Redis Sentinel mode, access the master container and execute the cache-clearing command.
+It is possible that the data inside the cache has become corrupted. Regardless of the reason, it is always safe to clear the cache — ThingsBoard will simply refill it at runtime. To clear the cache, you need to log into the server/container/pod where it is deployed, open the application command-line tool (<code>redis-cli</code> for Redis and <code>valkey-cli</code> for Valkey), and run the <code>FLUSHALL</code>command. To clear the cache in Sentinel mode, access the master container and execute the cache-clearing command.
 
-So if you are struggling with identifying the reason of some problem, you can safely clear Redis cache to make sure it isn't the reason of the issue.
+So if you are struggling with identifying the reason of some problem, you can safely clear cache to make sure it isn't the reason of the issue.
 
 
 ## Logs


### PR DESCRIPTION
## PR description
Valkey is a drop-in replacement for Redis.

According to PR's from S Matvienko(https://github.com/thingsboard/thingsboard/pull/12925/ and https://github.com/thingsboard/thingsboard-pe-docker-compose/pull/68), Thingsboard supports Valkey as a Cache Database. 

Thus, this PR adds Valkey reference where Redis is mentioned in the ThingsBoard documentation.

The documentation updated for: 
- config parameters
- MSA reference
- troubleshooting page
- attributes page

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
