### PR TITLE
Include docker compose file in repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,40 +88,23 @@ docker run --rm -p 4000:4000 --name thingsboard_website -e PAGES_REPO_NWO="thing
 
 ### Deploy the site using the docker-compose file
 
-Please replace the `THINGSBOARD_WEBSITE_DIR` with the full path to your local thingsboard.github.io repository.
-
->To deploy a fork, you need to replace the environment variable PAGES_REPO_NWO with the name of your repository.
+>To deploy a fork, you need to replace the environment variable PAGES_REPO_NWO (in `docker-compose.yaml`) with the name of your repository.
 As example:\
 `PAGES_REPO_NWO: "your_github_nickname/thingsboard.github.io"`
-
-Create docker-compose.yml file:
-
-```bash
-cat <<EOT | sudo tee docker-compose.yml
-version: '3.1'
-services:
-  thingsboard_website:
-    container_name: thingsboard_website
-    restart: always
-    image: "thingsboard/website"
-    environment:
-      PAGES_REPO_NWO: "thingsboard/thingsboard.github.io"
-    ports:
-      - "4000:4000"
-    volumes:
-      - THINGSBOARD_WEBSITE_DIR:/website
-EOT
-```
 
 To start the docker container with docker-compose, run the command:
 
 ```bash
-docker compose pull
-docker compose up
+docker compose up - d
 ```
 
-In about 2-7 minutes (depending on PC performance and cache), your copy of the site will be available for viewing at http://localhost:4000
+You can rebuild the website with:
 
+```bash
+docker compose restart
+```
+
+In about 2-7 minutes (depending on PC performance and cache), your copy of the site will be available for viewing at <http://localhost:4000>
 
 ## Image preview generator
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.1'
+services:
+  thingsboard_website:
+    container_name: thingsboard_website
+    restart: always
+    image: "thingsboard/website"
+    environment:
+      PAGES_REPO_NWO: "thingsboard/thingsboard.github.io"
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/website


### PR DESCRIPTION
## PR description

The docker-compose.yaml file included in the `README.md` to be moved into the repository, to allow easy building and launching of the website.

Documentation in the `README.md` updated to use the docker-compose.yaml file without the requirement to add it.

If you don't want to include this you can decline this pull request.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
