### PR TITLE
Update gateway connect documentation to include type

### DIFF
--- a/_includes/docs/reference/gateway-mqtt-api.md
+++ b/_includes/docs/reference/gateway-mqtt-api.md
@@ -20,11 +20,11 @@ In order to inform ThingsBoard that device is connected to the Gateway, one need
 
 ```shell
 Topic: v1/gateway/connect
-Message: {"device":"Device A"}
+Message: {"device":"Device A", "type": "Sensor A"}
 ```
 {: .copy-code}
 
-where **Device A** is your device name.
+where **Device A** is your device name and **Sensor A** is the name of your device profile, **type** is an optional key (**default** device profile will be used when no **type** is included).
 
 Once received, ThingsBoard will lookup or create a device with the name specified.
 Also, ThingsBoard will publish messages about new attribute updates and RPC commands for a particular device to this Gateway.


### PR DESCRIPTION
## PR description

The documentation updated for Gateway MQTT when connecting to include the `type` in the message. This already allows setting the device profile when connecting, but no documentation exists for this yet.

Explained that the type is optional and uses `default` if none is sent.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
