### PR TITLE
Installation-Upgrade guides upd

### DIFF
--- a/_includes/docs/edge/user-guide/config/edge-cluster-setup.md
+++ b/_includes/docs/edge/user-guide/config/edge-cluster-setup.md
@@ -1,8 +1,8 @@
 * TOC
 {:toc}
-  
+
 {% assign sinceVersion = "4.0" %}
-{% include templates/since.md %}
+{% include templates/edge/since-edge.md %}
 
 ### Overview
 
@@ -93,18 +93,18 @@ CLOUD_ROUTING_SECRET=PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
 {: .copy-code}
 
 View the full **.env** file:
-```bash
+```liquid
 # redis or redis-cluster or redis-sentinel
 CACHE=redis
 
 DOCKER_REPO=thingsboard
-{% if docsPrefix == "pe/edge/" %}
+{% if docsPrefix == "pe/edge/" -%}
 TB_EDGE_NODE_DOCKER_NAME=tb-edge-pe-node
 TB_EDGE_VERSION=latest
-{% else %}
+{%- else -%}
 TB_EDGE_NODE_DOCKER_NAME=tb-edge-node
 TB_EDGE_VERSION=latest
-{% endif %}
+{%- endif -%}
 # Database used by ThingsBoard, can be either postgres (PostgreSQL) or hybrid (PostgreSQL for entities database and Cassandra for timeseries database).
 # According to the database type corresponding docker service will be deployed (see docker-compose.postgres.yml, docker-compose.hybrid.yml for details).
 
@@ -113,14 +113,14 @@ TB_QUEUE_TYPE=kafka
 
 CLOUD_ROUTING_KEY=PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
 CLOUD_ROUTING_SECRET=PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
-{% if docsPrefix == "pe/edge/" %}
+{% if docsPrefix == "pe/edge/" -%}
 CLOUD_RPC_HOST=thingsboard.cloud
 CLOUD_RPC_PORT=7070
 CLOUD_RPC_SSL_ENABLED=true
-{% else %}
+{%- else -%}
 CLOUD_RPC_HOST=demo.thingsboard.io
 CLOUD_RPC_PORT=7070
-{% endif %}
+{%- endif -%}
 
 LOAD_BALANCER_NAME=haproxy-certbot
 
@@ -178,7 +178,7 @@ To start the service, execute the following command:
 
 {% capture install-and-run-edge %}
 It will take a few minutes to start the services. Once all services are successfully started, open the **ThingsBoard Edge** service
-at **http://{your-host-ip}** in the browser (_e.g., http://localhost_).
+at **```http://{your-host-ip}```** in the browser (_e.g., [http://localhost](http://localhost){: target="_blank"}_).
 To log in, use **the credentials** from the **ThingsBoard** account.
 {% endcapture %}
 {% include templates/info-banner.md content=install-and-run-edge %}
@@ -197,7 +197,7 @@ docker-compose ps
 
 To inspect the logs of all running services, use:
 ```bash
-docker-compose logs --f
+docker-compose logs -f
 ```
 {: .copy-code}
 

--- a/_includes/templates/edge/detaching-stop-start-edge.md
+++ b/_includes/templates/edge/detaching-stop-start-edge.md
@@ -1,7 +1,7 @@
-You can detach from session terminal using `Ctrl-p` `Ctrl-q` key sequence - the container will keep running in the background.
+You can detach from the session terminal using the key sequence **Ctrl+p** following by **Ctrl+q**. The container will keep running in the background.
 
-In case of any issues you can examine service logs for errors.
-For example to see {{serviceFullName}} container logs execute the following command:
+In case of any issues, you can examine service logs for errors.
+For example, to see the {{serviceFullName}} container logs, execute the following command:
 
 ```
 docker compose logs -f my{{serviceName}}
@@ -9,15 +9,25 @@ docker compose logs -f my{{serviceName}}
 {: .copy-code}
 
 To stop the container:
-
 ```
 docker compose stop my{{serviceName}}
 ```
 {: .copy-code}
 
-To start the container:
+To stop **all** containers, use the following command:
+```bash
+docker stop $(docker ps -q)
+```
+{: .copy-code}
 
+To start the container:
 ```
 docker compose start my{{serviceName}}
+```
+{: .copy-code}
+
+To start **all** containers, use the following command:
+```bash
+docker start $(docker ps -aq)
 ```
 {: .copy-code}

--- a/_includes/templates/edge/docker-queue-in-memory.md
+++ b/_includes/templates/edge/docker-queue-in-memory.md
@@ -1,7 +1,11 @@
-Create the **docker compose file** and populate it with configuration lines:
-
+Create the **docker compose file**:
+```bash
+nano docker-compose.yml
 ```
-cat > docker-compose.yml <<EOF && docker compose -f docker-compose.yml up -d
+{: .copy-code}
+
+Add the following lines to the **yml file**:
+```
 version: '3.8'
 services:
   mytbedge:
@@ -37,7 +41,6 @@ volumes:
     name: tb-edge-logs
   tb-edge-postgres-data:
     name: tb-edge-postgres-data
-EOF
 ```
 {: .copy-code.expandable-15}
 

--- a/_includes/templates/edge/install/docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/docker-queue-hybrid.md
@@ -2,10 +2,14 @@
 
 [Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
-Create the **docker compose file** and populate it with configuration lines:
-
+Create the **docker compose file**:
+```bash
+nano docker-compose.yml
 ```
-cat > docker-compose.yml <<EOF && docker compose -f docker-compose.yml up -d
+{: .copy-code}
+
+Add the following configuration lines to the **yml file**:
+```
 version: '3.8'
 services:
   mytbedge:
@@ -21,7 +25,7 @@ services:
       CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
       CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
       TB_QUEUE_TYPE: "kafka"
-      TB_KAFKA_SERVERS: "kafka:9092"
+      TB_KAFKA_SERVERS: "kafka:9094"
       DATABASE_TS_TYPE: "cassandra"
       CASSANDRA_URL: "cassandra:9042"
     volumes:
@@ -72,8 +76,6 @@ services:
       - 9042:9042
     volumes:
       - ./data/cassandra:/var/lib/cassandra
-    networks:
-      - cassandra-network
 volumes:
   tb-edge-data:
     name: tb-edge-data
@@ -83,10 +85,6 @@ volumes:
     name: tb-edge-postgres-data
   kafka-data:
     driver: local
-networks:
-  cassandra-network:
-    driver: bridge
-EOF
 ```
 {: .copy-code.expandable-15}
 

--- a/_includes/templates/edge/install/docker-queue-kafka.md
+++ b/_includes/templates/edge/install/docker-queue-kafka.md
@@ -1,9 +1,14 @@
 [Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
-Create the **docker compose file** and populate it with configuration lines:
+Create the **docker compose file**:
+```bash
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following configuration lines to the **yml file**:
 
 ```
-cat > docker-compose.yml <<EOF && docker compose -f docker-compose.yml up -d
 version: '3.8'
 services:
   mytbedge:
@@ -19,7 +24,7 @@ services:
       CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
       CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
       TB_QUEUE_TYPE: "kafka"
-      TB_KAFKA_SERVERS: "kafka:9092"
+      TB_KAFKA_SERVERS: "kafka:9094"
     volumes:
       - tb-edge-data:/data
       - tb-edge-logs:/var/log/tb-edge
@@ -65,7 +70,6 @@ volumes:
     name: tb-edge-postgres-data
   kafka-data:
     driver: local
-EOF
 ```
 {: .copy-code.expandable-15}
 

--- a/_includes/templates/edge/install/docker_compose_details_explain.md
+++ b/_includes/templates/edge/install/docker_compose_details_explain.md
@@ -5,34 +5,34 @@
 {% endif %}
 
 Where:    
-- `restart: always` - automatically start ThingsBoard Edge in case of system reboot and restart in case of failure;
-- `8080:8080` - connect local port 8080 to exposed internal HTTP port 8080;
-- `1883:1883` - connect local port 1883 to exposed internal MQTT port 1883;
-- `5683-5688:5683-5688/udp` - connect local UDP ports 5683-5688 to exposed internal COAP and LwM2M ports;
+- **restart: always:** ThingsBoard Edge automatically starts on system reboot or after a failure.
+- **8080:8080:** Connect local port 8080 to the container's internal HTTP port 8080.
+- **1883:1883:** Connect local port 1883 to the container's internal MQTT port 1883.
+- **5683-5688:5683-5688/udp:** Connect local UDP ports 5683–5688 to the container’s internal CoAP and LwM2M ports.
 {% if docsPrefix == 'pe/edge/' %}
-- `thingsboard/tb-edge-pe:{{ site.release.pe_edge_full_ver }}` - docker image;
+- **thingsboard/tb-edge-pe:{{ site.release.pe_edge_full_ver }}:** The ThingsBoard Edge PE Docker image.
 {% else %}
-- `thingsboard/tb-edge:{{ site.release.edge_full_ver }}` - docker image;
+- **thingsboard/tb-edge:{{ site.release.edge_full_ver }}:** The ThingsBoard Edge Docker image.
 {% endif %}
-- `CLOUD_ROUTING_KEY` - your edge key;
-- `CLOUD_ROUTING_SECRET` - your edge secret;
-- `CLOUD_RPC_HOST` - ip address of the machine with the ThingsBoard platform;
+- **CLOUD_ROUTING_KEY:** Enter the actual Edge key.
+- **CLOUD_ROUTING_SECRET:** Enter the actual Edge secret.
+- **CLOUD_RPC_HOST:** he IP address or hostname of the machine running the ThingsBoard platform.
 {% if docsPrefix == 'pe/edge/' %}
-- `CLOUD_RPC_SSL_ENABLED` - enable or disable SSL connection to server from edge.
+- **CLOUD_RPC_SSL_ENABLED:** Defines whether SSL is used for the connection between Edge and the ThingsBoard server. Use _true_ to enable SSL, or _false_ to disable it.
 {% endif %}
 
 {% capture cloud_rpc_host %}
 Please set **CLOUD_RPC_HOST** with an IP address of the machine where {{appPrefix}} version is running:
 * DO NOT use **'localhost'** - **'localhost'** is the ip address of the edge service in the docker container.
 {% if docsPrefix == 'pe/edge/' %}
-* Use **thingsboard.cloud** in case you are connecting edge to [**ThingsBoard Cloud**](https://thingsboard.cloud/signup).
+* Use **thingsboard.cloud** if you are connecting Edge to the [**ThingsBoard Cloud**](https://thingsboard.cloud/signup){: target="_blank"}.
 
 **NOTE**: **thingsboard.cloud** uses SSL protocol for edge communication.
 Please change **CLOUD_RPC_SSL_ENABLED** to **true** as well.
 {% else %}
-* Use **demo.thingsboard.io** if you are connecting edge to [**ThingsBoard Live Demo**](https://demo.thingsboard.io/signup) for evaluation.
+* Use **demo.thingsboard.io** if you are connecting Edge to the [**ThingsBoard Live Demo**](https://demo.thingsboard.io/signup){: target="_blank"} for evaluation.
 {% endif %}
-* Use **X.X.X.X** IP address in case edge is connecting to the cloud instance in the same network or in the docker.
+* Use **X.X.X.X** IP address if the Edge is connected to the Cloud instance in the same network or Docker environment.
 
 {% endcapture %}
 {% include templates/info-banner.md content=cloud_rpc_host %}
@@ -42,7 +42,7 @@ If **ThingsBoard Edge** is set to run on the **same machine** where the **{{appP
 
 Ensure that the ports **18080, 11883, 15683-15688** are not used by any other application.
 
-Then, update the port configuration in the `docker-compose.yml` file:
+Then, update the port configuration in the **docker-compose.yml** file:
 
 **sed -i 's/8080:8080/18080:8080/; s/1883:1883/11883:1883/; s/5683-5688:5683-5688\/udp/15683-15688:5683-5688\/udp/' docker-compose.yml**
 

--- a/_includes/templates/edge/install/edge-service-commands.md
+++ b/_includes/templates/edge/install/edge-service-commands.md
@@ -1,23 +1,23 @@
 
-Start edge service:
+Start the **ThingsBoard Edge** service:
 ```bash
 sudo service tb-edge start
 ```
 {: .copy-code}
 
-Stop edge service:
+Stop the **ThingsBoard Edge** service:
 ```bash
 sudo service tb-edge stop
 ```
 {: .copy-code}
 
-Restart edge service:
+Restart the **ThingsBoard Edge** service:
 ```bash
 sudo service tb-edge restart
 ```
 {: .copy-code}
 
-Check status of ThingsBoard Edge service:
+Check the status of the **ThingsBoard Edge** service:
 ```bash
 sudo service tb-edge status
 ```

--- a/_includes/templates/edge/install/pe-docker-queue-hybrid.md
+++ b/_includes/templates/edge/install/pe-docker-queue-hybrid.md
@@ -2,10 +2,15 @@
 
 [Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
-Create the **docker compose file** and populate it with configuration lines:
+Create the **docker compose file**:
+```bash
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following configuration lines to the **yml file**:
 
 ```
-cat > docker-compose.yml <<EOF && docker compose -f docker-compose.yml up -d
 version: '3.8'
 services:
   mytbedge:
@@ -20,17 +25,17 @@ services:
       EDGE_LICENSE_INSTANCE_DATA_FILE: /data/instance-edge-license.data
       CLOUD_ROUTING_KEY: PUT_YOUR_EDGE_KEY_HERE # e.g. 19ea7ee8-5e6d-e642-4f32-05440a529015
       CLOUD_ROUTING_SECRET: PUT_YOUR_EDGE_SECRET_HERE # e.g. bztvkvfqsye7omv9uxlp
-      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or demo.thingsboard.io
+      CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. 192.168.1.1 or thingsboard.cloud
       CLOUD_RPC_SSL_ENABLED: 'false' # set it to 'true' if you are connecting edge to thingsboard.cloud
       TB_QUEUE_TYPE: "kafka"
-      TB_KAFKA_SERVERS: "kafka:9092"
+      TB_KAFKA_SERVERS: "kafka:9094"
       DATABASE_TS_TYPE: "cassandra"
       CASSANDRA_URL: "cassandra:9042"
-      volumes:
-        - tb-edge-data:/data
-        - tb-edge-logs:/var/log/tb-edge
-      extra_hosts:
-        - "host.docker.internal:host-gateway"
+    volumes:
+      - tb-edge-data:/data
+      - tb-edge-logs:/var/log/tb-edge
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   postgres:
     restart: always
     image: "postgres:15"
@@ -76,8 +81,6 @@ services:
       - 9042:9042
     volumes:
       - ./data/cassandra:/var/lib/cassandra
-    networks:
-      - cassandra-network
 volumes:
   tb-edge-data:
     name: tb-edge-data
@@ -87,10 +90,6 @@ volumes:
     name: tb-edge-postgres-data
   kafka-data:
     driver: local
-networks:
-  cassandra-network:
-    driver: bridge
-EOF
 ```
 {: .copy-code.expandable-15}
 

--- a/_includes/templates/edge/install/pe-docker-queue-kafka.md
+++ b/_includes/templates/edge/install/pe-docker-queue-kafka.md
@@ -1,10 +1,14 @@
 
 [Apache Kafka](https://kafka.apache.org/){: target="_blank"} is an open source stream processing software platform.
 
-Create the **docker compose file** and populate it with configuration lines:
-
+Create the **docker compose file** 
+```bash
+nano docker-compose.yml
 ```
-cat > docker-compose.yml <<EOF && docker compose -f docker-compose.yml up -d
+{: .copy-code}
+
+Add the following configuration lines to the file:
+```
 version: '3.8'
 services:
   mytbedge:
@@ -22,7 +26,7 @@ services:
       CLOUD_RPC_HOST: PUT_YOUR_CLOUD_IP # e.g. host.docker.internal, 192.168.1.1 or thingsboard.cloud, etc.
       CLOUD_RPC_SSL_ENABLED: 'false' # set it to 'true' if you are connecting edge to thingsboard.cloud
       TB_QUEUE_TYPE: "kafka"
-      TB_KAFKA_SERVERS: "kafka:9092"
+      TB_KAFKA_SERVERS: "kafka:9094"
     volumes:
       - tb-edge-data:/data
       - tb-edge-logs:/var/log/tb-edge
@@ -70,7 +74,6 @@ volumes:
     name: tb-edge-postgres-data
   kafka-data:
     driver: local
-EOF
 ```
 {: .copy-code.expandable-15}
 

--- a/_includes/templates/edge/pe-docker-queue-in-memory.md
+++ b/_includes/templates/edge/pe-docker-queue-in-memory.md
@@ -1,8 +1,13 @@
-For **ThingsBoard Edge** service, create docker compose file and populate it with configuration lines:
+For **ThingsBoard Edge** service, create a docker compose file:
 
+```bash
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following configuration lines to the **yml file**:
 
 ```
-cat > docker-compose.yml <<EOF && docker compose -f docker-compose.yml up -d
 version: '3.8'
 services:
   mytbedge:
@@ -32,7 +37,7 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - tb-edge-postgres-data:/var/lib/postgresql/data
-
+      
 volumes:
   tb-edge-data:
     name: tb-edge-data
@@ -40,7 +45,6 @@ volumes:
     name: tb-edge-logs
   tb-edge-postgres-data:
     name: tb-edge-postgres-data
-EOF
 ```
 {: .copy-code.expandable-15}
 

--- a/_includes/templates/edge/user-guide/backup/docker-restore-backup.md
+++ b/_includes/templates/edge/user-guide/backup/docker-restore-backup.md
@@ -1,0 +1,20 @@
+Stop the **ThingsBoard Edge** container (if it's still running):
+
+```bash
+docker compose stop
+```
+{: .copy-code}
+
+To restore data from a backup volume to the main volume, run the following command:
+
+```bash
+docker run --rm -v tb-edge-postgres-data-backup:/source -v tb-edge-postgres-data:/target busybox sh -c "cp -a /source/. /target"
+ ```
+{: .copy-code}
+
+Start the **ThingsBoard Edge** container:
+
+```bash
+docker compose up -d 
+```
+{: .copy-code}

--- a/_includes/templates/edge/user-guide/backup/ubuntu-restore-backup.md
+++ b/_includes/templates/edge/user-guide/backup/ubuntu-restore-backup.md
@@ -1,0 +1,22 @@
+Stop the **ThingsBoard Edge** service (if it's still running):
+
+```bash
+sudo systemctl stop tb-edge
+```
+{: .copy-code}
+
+To restore the **PostgreSQL database** from a backup file, run the following command: 
+
+```bash
+ sudo -u postgres psql tb_edge < tb_edge.sql.bak
+ ```
+{: .copy-code}
+
+Start the **ThingsBoard Edge** service:
+
+```bash
+sudo systemctl start tb-edge
+```
+{: .copy-code}
+
+

--- a/_includes/templates/edge/user-guide/start-upgrade-pe.md
+++ b/_includes/templates/edge/user-guide/start-upgrade-pe.md
@@ -2,11 +2,9 @@ _**NOTE**: These steps are applicable for ThingsBoard {{previousVersion}} versio
 
 Set the terminal in the directory which contains the "docker-compose.yml" file, and run the following command to stop and remove the currently running TB Edge container (if it's still running):
 ```
-docker compose stop && docker compose rm mytbedge -f
+docker compose stop mytbedge
 ```
 {: .copy-code}
-
-#### Backup Database
 
 Before upgrading, make a copy of the database volume:
 
@@ -15,45 +13,6 @@ docker run --rm -v tb-edge-postgres-data:/source -v tb-edge-postgres-data-backup
 ```
 {: .copy-code}
 
-The next step creates a docker compose file for the **ThingsBoard Edge upgrade** process and runs the upgrade. 
-Once the upgrade process is successfully completed, the TB Edge upgrade container is automatically stopped:
-
-```
-cat > docker-compose-upgrade.yml <<EOF && docker compose -f docker-compose-upgrade.yml up --abort-on-container-exit
-version: '3.8'
-services:
-  mytbedge:
-    restart: on-failure
-    image: "thingsboard/tb-edge-pe:{{versionName}}"
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
-    volumes:
-      - tb-edge-data:/data
-      - tb-edge-logs:/var/log/tb-edge
-    entrypoint: upgrade-tb-edge.sh
-  postgres:
-    restart: always
-    image: "postgres:15"
-    ports:
-      - "5432"
-    environment:
-      POSTGRES_DB: tb-edge
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - tb-edge-postgres-data:/var/lib/postgresql/data
-
-volumes:
-  tb-edge-data:
-    name: tb-edge-data
-  tb-edge-logs:
-    name: tb-edge-logs
-  tb-edge-postgres-data:
-    name: tb-edge-postgres-data
-
-EOF
-```
-{: .copy-code.expandable-9}
-
 Modify the main docker compose file (docker-compose.yml) for **ThingsBoard Edge** and update the image version:
 
 ```text
@@ -61,7 +20,7 @@ sed -i 's|thingsboard/tb-edge-pe:{{previousVersion}}|thingsboard/tb-edge-pe:{{ve
 ```
 {: .copy-code}
 
-Upgrade the ThingsBoard Edge service: 
+Upgrade the **ThingsBoard Edge** service: 
 
 ```bash
 docker compose run mytbedge upgrade-tb-edge.sh

--- a/_includes/templates/edge/user-guide/start-upgrade-pe.md
+++ b/_includes/templates/edge/user-guide/start-upgrade-pe.md
@@ -61,7 +61,14 @@ sed -i 's|thingsboard/tb-edge-pe:{{previousVersion}}|thingsboard/tb-edge-pe:{{ve
 ```
 {: .copy-code}
 
-To start this docker compose, run the following command:
+Upgrade the ThingsBoard Edge service: 
+
+```bash
+docker compose run mytbedge upgrade-tb-edge.sh
+```
+{: .copy-code}
+
+Start the docker compose:
 ```
 docker compose up -d && docker compose logs -f mytbedge
 ```

--- a/_includes/templates/edge/user-guide/start-upgrade.md
+++ b/_includes/templates/edge/user-guide/start-upgrade.md
@@ -2,11 +2,9 @@ _**NOTE**: These steps are applicable for ThingsBoard {{previousVersion}} versio
 
 Set the terminal in the directory which contains the "docker-compose.yml" file, and run the following command to stop and remove the currently running TB Edge container (if it's still running):
 ```
-docker compose stop && docker compose rm mytbedge -f
+docker compose stop mytbedge
 ```
 {: .copy-code}
-
-#### Backup Database
 
 Before upgrading, make a copy of the database volume:
 
@@ -15,48 +13,17 @@ docker run --rm -v tb-edge-postgres-data:/source -v tb-edge-postgres-data-backup
 ```
 {: .copy-code}
 
-The next step creates a docker compose file for the **ThingsBoard Edge upgrade** process and runs the upgrade. 
-Once the upgrade process is successfully completed, the TB Edge upgrade container is automatically stopped:
-
-```
-cat > docker-compose-upgrade.yml <<EOF && docker compose -f docker-compose-upgrade.yml up --abort-on-container-exit
-version: '3.8'
-services:
-  mytbedge:
-    restart: on-failure
-    image: "thingsboard/tb-edge:{{versionName}}"
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/tb-edge
-    volumes:
-      - tb-edge-data:/data
-      - tb-edge-logs:/var/log/tb-edge
-    entrypoint: upgrade-tb-edge.sh
-  postgres:
-    restart: always
-    image: "postgres:15"
-    ports:
-      - "5432"
-    environment:
-      POSTGRES_DB: tb-edge
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - tb-edge-postgres-data:/var/lib/postgresql/data
-
-volumes:
-  tb-edge-data:
-    name: tb-edge-data
-  tb-edge-logs:
-    name: tb-edge-logs
-  tb-edge-postgres-data:
-    name: tb-edge-postgres-data
-EOF
-```
-{: .copy-code.expandable-9}
-
 Modify the main docker compose file (docker-compose.yml) for **ThingsBoard Edge** and update the image version:
 
 ```text
 sed -i 's|thingsboard/tb-edge:{{previousVersion}}|thingsboard/tb-edge:{{versionName}}|' docker-compose.yml
+```
+{: .copy-code}
+
+Upgrade the **ThingsBoard Edge** service:
+
+```bash
+docker compose run mytbedge upgrade-tb-edge.sh
 ```
 {: .copy-code}
 

--- a/docs/edge/releases.md
+++ b/docs/edge/releases.md
@@ -8,123 +8,130 @@ description: ThingsBoard Edge Release Notes
 * TOC
 {:toc}
 
+## v4.0.1 (May 15, 2025) {#v401}
+
+**Major** release with everything (except the Calculated Fields feature) from [TB CE v4.0](/docs/reference/releases/#v40){: target="_blank"}:
+
+* [#9195](https://github.com/thingsboard/thingsboard/pull/9195){: target="_blank"} Run multiple Edge nodes in a clustered, high-availability setup by @AndriiLandiak;
+* [#131](https://github.com/thingsboard/thingsboard-edge/pull/131){: target="_blank"} Create and edit Rule Chains directly on Edge by @AndriiLandiak;
+
 ## v3.9.1 (Mar 14, 2025) {#v391}
 
-**Minor** release with everything from [TB CE v3.9.1](/docs/reference/releases/#v391).
+**Minor** release with everything from [TB CE v3.9.1](/docs/reference/releases/#v391){: target="_blank"}.
 
 ## v3.9.0 (Jan 13, 2025) {#v39}
 
-**Major** release with everything from [TB CE v3.9](/docs/reference/releases/#v39):
+**Major** release with everything from [TB CE v3.9](/docs/reference/releases/#v39){: target="_blank"}:
 
-* [#125](https://github.com/thingsboard/thingsboard-edge/pull/125) Use of Kafka to store and process Cloud Events to improve processing throughput by @jekka001;
-* [#136](https://github.com/thingsboard/thingsboard-edge/pull/136) Access Edge Attributes on edge instance itself @jekka001;
+* [#125](https://github.com/thingsboard/thingsboard-edge/pull/125){: target="_blank"} Use of Kafka to store and process Cloud Events to improve processing throughput by @jekka001;
+* [#136](https://github.com/thingsboard/thingsboard-edge/pull/136){: target="_blank"} Access Edge Attributes on edge instance itself @jekka001;
 * Cassandra support as Timeseries storage by @AndriiLandiak;
 
 ## v3.8.0 (Oct 15, 2024) {#v38}
 
-**Major** release with everything from [TB CE v3.8](/docs/reference/releases/#v38):
+**Major** release with everything from [TB CE v3.8](/docs/reference/releases/#v38){: target="_blank"}:
 
-* [#11521](https://github.com/thingsboard/thingsboard/pull/11521) Queue to handle edge notification messages by @AndriiLandiak;
-* [#11139](https://github.com/thingsboard/thingsboard/pull/11139) Proxy for grpc client by @AndriiLandiak;
-* [#11494](https://github.com/thingsboard/thingsboard/pull/11494) Performance improvement via caching related edges for entity by @AndriiLandiak;
-* [#120](https://github.com/thingsboard/thingsboard-edge/pull/120) Introduce Timeseries Cloud events table to slowly process timeseries updates by @AndriiLandiak;
+* [#11521](https://github.com/thingsboard/thingsboard/pull/11521){: target="_blank"} Queue to handle edge notification messages by @AndriiLandiak;
+* [#11139](https://github.com/thingsboard/thingsboard/pull/11139){: target="_blank"} Proxy for grpc client by @AndriiLandiak;
+* [#11494](https://github.com/thingsboard/thingsboard/pull/11494){: target="_blank"} Performance improvement via caching related edges for entity by @AndriiLandiak;
+* [#120](https://github.com/thingsboard/thingsboard-edge/pull/120){: target="_blank"} Introduce Timeseries Cloud events table to slowly process timeseries updates by @AndriiLandiak;
 
 ## v3.7.0 (Jun 18, 2024) {#v37}
 
-**Major** release with everything from [TB CE v3.7](/docs/reference/releases/#v37):
+**Major** release with everything from [TB CE v3.7](/docs/reference/releases/#v37){: target="_blank"}:
 
-* [#10548](https://github.com/thingsboard/thingsboard/pull/10548) Add support for notification center by @AndriiLandiak;
-* [#10239](https://github.com/thingsboard/thingsboard/pull/10239) Sync up OAuth2 configuration by @AndriiLandiak;
-* [#10471](https://github.com/thingsboard/thingsboard/pull/10471) YAML configuration for telemetry message size limit with Edge Notification by @AndriiLandiak;
+* [#10548](https://github.com/thingsboard/thingsboard/pull/10548){: target="_blank"} Add support for notification center by @AndriiLandiak;
+* [#10239](https://github.com/thingsboard/thingsboard/pull/10239){: target="_blank"} Sync up OAuth2 configuration by @AndriiLandiak;
+* [#10471](https://github.com/thingsboard/thingsboard/pull/10471){: target="_blank"} YAML configuration for telemetry message size limit with Edge Notification by @AndriiLandiak;
 
 ## v3.6.4 (Apr 11, 2024) {#v364}
 
-**Minor** release with everything from [TB CE v3.6.4](/docs/reference/releases/#v364).
+**Minor** release with everything from [TB CE v3.6.4](/docs/reference/releases/#v364){: target="_blank"}.
 
 ## v3.6.3 (Mar 18, 2024) {#v363}
 
-**Minor** release with everything from [TB CE v3.6.3](/docs/reference/releases/#v363):
+**Minor** release with everything from [TB CE v3.6.3](/docs/reference/releases/#v363){: target="_blank"}:
 
-* [#9968](https://github.com/thingsboard/thingsboard/pull/9968) Alarm comment support by @AndriiLandiak;
-* [#10021](https://github.com/thingsboard/thingsboard/pull/10021) Notification rules for connection status and errors. Rate limits for Edge events by @AndriiLandiak;
+* [#9968](https://github.com/thingsboard/thingsboard/pull/9968){: target="_blank"} Alarm comment support by @AndriiLandiak;
+* [#10021](https://github.com/thingsboard/thingsboard/pull/10021){: target="_blank"} Notification rules for connection status and errors. Rate limits for Edge events by @AndriiLandiak;
 
 ## v3.6.2 (Dec 28, 2023) {#v362}
 
-**Minor** release with everything from [TB CE v3.6.2](/docs/reference/releases/#v362):
+**Minor** release with everything from [TB CE v3.6.2](/docs/reference/releases/#v362){: target="_blank"}:
 
-* [#9688](https://github.com/thingsboard/thingsboard/pull/9688) Edge upgrade instructions in TB Server by @AndriiLandiak and @deaflynx;
-* [#9617](https://github.com/thingsboard/thingsboard/pull/9617) Edge - JSON converter for proto by @AndriiLandiak;
-* [#9712](https://github.com/thingsboard/thingsboard/pull/9712) Edge Requests Service - fetch only first level of relation from cloud by @volodymyr-babak; 
+* [#9688](https://github.com/thingsboard/thingsboard/pull/9688){: target="_blank"} Edge upgrade instructions in TB Server by @AndriiLandiak and @deaflynx;
+* [#9617](https://github.com/thingsboard/thingsboard/pull/9617){: target="_blank"} Edge - JSON converter for proto by @AndriiLandiak;
+* [#9712](https://github.com/thingsboard/thingsboard/pull/9712){: target="_blank"} Edge Requests Service - fetch only first level of relation from cloud by @volodymyr-babak; 
 
 ## v3.6.1 (Nov 14, 2023) {#v361}
 
-**Minor** release with everything from [TB CE v3.6.1](/docs/reference/releases/#v361) with the following improvements and bug fixes:
+**Minor** release with everything from [TB CE v3.6.1](/docs/reference/releases/#v361){: target="_blank"} with the following improvements and bug fixes:
 
-* [#9226](https://github.com/thingsboard/thingsboard/pull/9226) TB Resource functionality support for Edge by @AndriiLandiak;
-* [#9515](https://github.com/thingsboard/thingsboard/pull/9515) Increased default value of EDGES_SLEEP_BETWEEN_BATCHES to handle 2G/3G connections by @volodymyr-babak;
+* [#9226](https://github.com/thingsboard/thingsboard/pull/9226){: target="_blank"} TB Resource functionality support for Edge by @AndriiLandiak;
+* [#9515](https://github.com/thingsboard/thingsboard/pull/9515){: target="_blank"} Increased default value of EDGES_SLEEP_BETWEEN_BATCHES to handle 2G/3G connections by @volodymyr-babak;
 
 ## v3.6.0 (Sep 22, 2023) {#v36}
 
-**Major** release with everything from [TB CE v3.6](/docs/reference/releases/#v36) with the following improvements and bug fixes:
+**Major** release with everything from [TB CE v3.6](/docs/reference/releases/#v36){: target="_blank"} with the following improvements and bug fixes:
 
-* [#9087](https://github.com/thingsboard/thingsboard/pull/9087) Add possibility to create Assets, Dashboards, EntityViews, AssetProfile, DeviceProfile on edge by @AndriiLandiak;
-* [#9062](https://github.com/thingsboard/thingsboard/pull/9062) Push tenant and tenant profile entities to the edge by @AndriiLandiak;
-* [#9052](https://github.com/thingsboard/thingsboard/pull/9052) Introduce Event Pub/Sub Model for Detecting Changes in Entities by @AndriiLandiak;
-* [#8830](https://github.com/thingsboard/thingsboard/pull/8830) Edge event table - added sequential ID column to handle properly heavy load and cluster cases by @volodymyr-babak;
-* [#9245](https://github.com/thingsboard/thingsboard/pull/9245) Edge instructions for ubuntu, centos by @deaflynx and @AndriiLandiak;
+* [#9087](https://github.com/thingsboard/thingsboard/pull/9087){: target="_blank"} Add possibility to create Assets, Dashboards, EntityViews, AssetProfile, DeviceProfile on edge by @AndriiLandiak;
+* [#9062](https://github.com/thingsboard/thingsboard/pull/9062){: target="_blank"} Push tenant and tenant profile entities to the edge by @AndriiLandiak;
+* [#9052](https://github.com/thingsboard/thingsboard/pull/9052){: target="_blank"} Introduce Event Pub/Sub Model for Detecting Changes in Entities by @AndriiLandiak;
+* [#8830](https://github.com/thingsboard/thingsboard/pull/8830){: target="_blank"} Edge event table - added sequential ID column to handle properly heavy load and cluster cases by @volodymyr-babak;
+* [#9245](https://github.com/thingsboard/thingsboard/pull/9245){: target="_blank"} Edge instructions for ubuntu, centos by @deaflynx and @AndriiLandiak;
 
 ## v3.5.1.1 (Jul 4, 2023) {#v3511}
 
 **Hotfix** release to fix incorrect update of sequential id offset:
 
-* [#57](https://github.com/thingsboard/thingsboard-edge/issues/57) ThingsBoard Edge PE disconnects from cloud;
-* [#60](https://github.com/thingsboard/thingsboard-edge/issues/60) edge error log;
+* [#57](https://github.com/thingsboard/thingsboard-edge/issues/57){: target="_blank"} ThingsBoard Edge PE disconnects from cloud;
+* [#60](https://github.com/thingsboard/thingsboard-edge/issues/60){: target="_blank"} edge error log;
 
 ## v3.5.1 (Jun 1, 2023) {#v351}
 
-**Minor** release with everything from [TB CE v3.5.1](/docs/reference/releases/#v351).
+**Minor** release with everything from [TB CE v3.5.1](/docs/reference/releases/#v351){: target="_blank"}.
 
 ## v3.5.0 (May 10, 2023) {#v35}
 
-**Major** release with everything from [TB CE v3.5](/docs/reference/releases/#v35) with the following improvements and bug fixes:
+**Major** release with everything from [TB CE v3.5](/docs/reference/releases/#v35){: target="_blank"} with the following improvements and bug fixes:
 
-* [#7862](https://github.com/thingsboard/thingsboard/pull/7862) Push latest timeseries key-value pair to edge on assignment entity to edge;
-* [#7878](https://github.com/thingsboard/thingsboard/pull/7878) Add edge install instructions for docker;
-* [#7914](https://github.com/thingsboard/thingsboard/pull/7914) Added default edge rule chain to asset/device profiles;
-* [#8301](https://github.com/thingsboard/thingsboard/pull/8301) Edge computing solution templates;
-* [#8340](https://github.com/thingsboard/thingsboard/pull/8340) Handle gRPC messages exceeding default max message size;
-* [#8344](https://github.com/thingsboard/thingsboard/pull/8344) Push edge connect/disconnect events to rule chain;
-* [#8346](https://github.com/thingsboard/thingsboard/pull/8346) Improved Keep Alive Functionality between Edge and Cloud to Prevent Data Loss;
+* [#7862](https://github.com/thingsboard/thingsboard/pull/7862){: target="_blank"} Push latest timeseries key-value pair to edge on assignment entity to edge;
+* [#7878](https://github.com/thingsboard/thingsboard/pull/7878){: target="_blank"} Add edge install instructions for docker;
+* [#7914](https://github.com/thingsboard/thingsboard/pull/7914){: target="_blank"} Added default edge rule chain to asset/device profiles;
+* [#8301](https://github.com/thingsboard/thingsboard/pull/8301){: target="_blank"} Edge computing solution templates;
+* [#8340](https://github.com/thingsboard/thingsboard/pull/8340){: target="_blank"} Handle gRPC messages exceeding default max message size;
+* [#8344](https://github.com/thingsboard/thingsboard/pull/8344){: target="_blank"} Push edge connect/disconnect events to rule chain;
+* [#8346](https://github.com/thingsboard/thingsboard/pull/8346){: target="_blank"} Improved Keep Alive Functionality between Edge and Cloud to Prevent Data Loss;
 
 ## v3.4.3 (December 22, 2022)
 
-**Minor** release with everything from [TB CE v3.4.3](/docs/reference/releases/#v343-december-21-2022) with the following improvements and bug fixes:
+**Minor** release with everything from [TB CE v3.4.3](/docs/reference/releases/#v343-december-21-2022){: target="_blank"} with the following improvements and bug fixes:
 
-* [#7093](https://github.com/thingsboard/thingsboard/pull/7093) Edge sync functionality - added cluster support;
-* [#7214](https://github.com/thingsboard/thingsboard/pull/7214) Notify devices in case shared attribute updates from edge;
-* [#7651](https://github.com/thingsboard/thingsboard/pull/7651) Updates to stability of synchronization between edge and cloud in case of many events simultaneously;
-* [#7792](https://github.com/thingsboard/thingsboard/pull/7792) Edge root rule chain update fix. USER entity support added. INACTIVITY_TIMEOUT pushed to edge;
+* [#7093](https://github.com/thingsboard/thingsboard/pull/7093){: target="_blank"} Edge sync functionality - added cluster support;
+* [#7214](https://github.com/thingsboard/thingsboard/pull/7214){: target="_blank"} Notify devices in case shared attribute updates from edge;
+* [#7651](https://github.com/thingsboard/thingsboard/pull/7651){: target="_blank"} Updates to stability of synchronization between edge and cloud in case of many events simultaneously;
+* [#7792](https://github.com/thingsboard/thingsboard/pull/7792){: target="_blank"} Edge root rule chain update fix. USER entity support added. INACTIVITY_TIMEOUT pushed to edge;
 
 ## v3.4.1 (August 19, 2022)
 
-**Minor** release with everything from [TB CE v3.4.1](/docs/reference/releases/#v341-august-18-2022) with the following improvements and bug fixes:
+**Minor** release with everything from [TB CE v3.4.1](/docs/reference/releases/#v341-august-18-2022){: target="_blank"} with the following improvements and bug fixes:
 
-* [#6953](https://github.com/thingsboard/thingsboard/pull/6953) Check for missing edge rule chain during unassign of rule chain(s) from edge;
-* [#7044](https://github.com/thingsboard/thingsboard/pull/7044) Firmware ID not synced from cloud to edge in device / device profiles;
-* [#7095](https://github.com/thingsboard/thingsboard/pull/7095) Start regular edge event process after sync completed;
+* [#6953](https://github.com/thingsboard/thingsboard/pull/6953){: target="_blank"} Check for missing edge rule chain during unassign of rule chain(s) from edge;
+* [#7044](https://github.com/thingsboard/thingsboard/pull/7044){: target="_blank"} Firmware ID not synced from cloud to edge in device / device profiles;
+* [#7095](https://github.com/thingsboard/thingsboard/pull/7095){: target="_blank"} Start regular edge event process after sync completed;
 
 ## v3.4 (July 21, 2022)
 
-Everything from [TB CE v3.4](/docs/reference/releases/#v34-july-19-2022) with the following improvements and bug fixes:
+Everything from [TB CE v3.4](/docs/reference/releases/#v34-july-19-2022){: target="_blank"} with the following improvements and bug fixes:
 
-* [#6781](https://github.com/thingsboard/thingsboard/pull/6781) Edge OTA support;
-* [#6852](https://github.com/thingsboard/thingsboard/pull/6852) Queue API support.
+* [#6781](https://github.com/thingsboard/thingsboard/pull/6781){: target="_blank"} Edge OTA support;
+* [#6852](https://github.com/thingsboard/thingsboard/pull/6852){: target="_blank"} Queue API support.
 
 ## v3.3.4.1 (May 2, 2022)
 
 **Hot fix** release with the following bug fixes:
 * Core:
-    * Fix issue with duplicate system widget bundles that cause an error during widget loading on the dashboard [details](https://github.com/thingsboard/thingsboard-edge/issues/5)
+    * Fix issue with duplicate system widget bundles that cause an error during widget loading on the dashboard [details](https://github.com/thingsboard/thingsboard-edge/issues/5){: target="_blank"}
 
 ## v3.3.4 (March 24, 2022)
 

--- a/docs/pe/edge/releases.md
+++ b/docs/pe/edge/releases.md
@@ -8,62 +8,66 @@ description: ThingsBoard Edge Release Notes
 * TOC
 {:toc}
 
+## v4.0.1 (May 15, 2025) {#v401}
+
+**Major** release with everything (except the Calculated Fields feature) from [TB Edge v4.0.1](/docs/edge/releases/#v401){: target="_blank"} and [TB PE v4.0.1](/docs/pe/reference/releases/#v40){: target="_blank"}.
+
 ## v3.9.1 (Mar 14, 2025) {#v391}
 
-**Minor** release with everything from [TB Edge v3.9.1](/docs/edge/releases/#v391) and [TB PE v3.9.1](/docs/pe/reference/releases/#v391).
+**Minor** release with everything from [TB Edge v3.9.1](/docs/edge/releases/#v391){: target="_blank"} and [TB PE v3.9.1](/docs/pe/reference/releases/#v391){: target="_blank"}.
 
 ## v3.9.0 (Jan 13, 2025) {#v39}
 
-**Major** release with everything from [TB Edge v3.9](/docs/edge/releases/#v39) and [TB PE v3.9](/docs/pe/reference/releases/#v39).
+**Major** release with everything from [TB Edge v3.9](/docs/edge/releases/#v39){: target="_blank"} and [TB PE v3.9](/docs/pe/reference/releases/#v39){: target="_blank"}.
 
 ## v3.8.0 (Oct 15, 2024) {#v38}
 
-**Major** release with everything from [TB Edge v3.8](/docs/edge/releases/#v38) and [TB PE v3.8](/docs/pe/reference/releases/#v38).
+**Major** release with everything from [TB Edge v3.8](/docs/edge/releases/#v38){: target="_blank"} and [TB PE v3.8](/docs/pe/reference/releases/#v38){: target="_blank"}.
 
 ## v3.7.0 (Jun 18, 2024) {#v37}
 
-**Major** release with everything from [TB Edge v3.7](/docs/edge/releases/#v37) and [TB PE v3.7](/docs/pe/reference/releases/#v37).
+**Major** release with everything from [TB Edge v3.7](/docs/edge/releases/#v37){: target="_blank"} and [TB PE v3.7](/docs/pe/reference/releases/#v37){: target="_blank"}.
 
 ## v3.6.4 (Apr 11, 2024) {#v364}
 
-**Minor** release with everything from [TB Edge v3.6.4](/docs/edge/releases/#v364) and [TB PE v3.6.4](/docs/pe/reference/releases/#v364).
+**Minor** release with everything from [TB Edge v3.6.4](/docs/edge/releases/#v364){: target="_blank"} and [TB PE v3.6.4](/docs/pe/reference/releases/#v364){: target="_blank"}.
   
 ## v3.6.3 (Mar 18, 2024) {#v363}
 
-**Minor** release with everything from [TB Edge v3.6.3](/docs/edge/releases/#v363) and [TB PE v3.6.3](/docs/pe/reference/releases/#v363).
+**Minor** release with everything from [TB Edge v3.6.3](/docs/edge/releases/#v363){: target="_blank"} and [TB PE v3.6.3](/docs/pe/reference/releases/#v363){: target="_blank"}.
 
 ## v3.6.2 (Dec 28, 2023) {#v362}
 
-**Minor** release with everything from [TB Edge v3.6.2](/docs/edge/releases/#v362) and [TB PE v3.6.2](/docs/pe/reference/releases/#v362).
+**Minor** release with everything from [TB Edge v3.6.2](/docs/edge/releases/#v362){: target="_blank"} and [TB PE v3.6.2](/docs/pe/reference/releases/#v362){: target="_blank"}.
 
 ## v3.6.1 (Nov 14, 2023) {#v361}
 
-**Minor** release with everything from [TB Edge v3.6.1](/docs/edge/releases/#v361) and [TB PE v3.6.1](/docs/pe/reference/releases/#v361).
+**Minor** release with everything from [TB Edge v3.6.1](/docs/edge/releases/#v361){: target="_blank"} and [TB PE v3.6.1](/docs/pe/reference/releases/#v361){: target="_blank"}.
 
 ## v3.6.0 (Sep 22, 2023) {#v36}
 
-**Major** release with everything from [TB Edge v3.6](/docs/edge/releases/#v36) and [TB PE v3.6](/docs/pe/reference/releases/#v36).
+**Major** release with everything from [TB Edge v3.6](/docs/edge/releases/#v36){: target="_blank"} and [TB PE v3.6](/docs/pe/reference/releases/#v36){: target="_blank"}.
 
 ## v3.5.1.1 (Jul 4, 2023) {#v3511}
 
 **Hotfix** release to fix incorrect update of sequential id offset:
 
-* [#57](https://github.com/thingsboard/thingsboard-edge/issues/57) ThingsBoard Edge PE disconnects from cloud;
-* [#60](https://github.com/thingsboard/thingsboard-edge/issues/60) edge error log;
+* [#57](https://github.com/thingsboard/thingsboard-edge/issues/57){: target="_blank"} ThingsBoard Edge PE disconnects from cloud;
+* [#60](https://github.com/thingsboard/thingsboard-edge/issues/60){: target="_blank"} edge error log;
 
 ## v3.5.1 (Jun 1, 2023) {#v351}
 
-**Minor** release with everything from [TB Edge v3.5.1](/docs/edge/releases/#v351) and [TB PE v3.5.1](/docs/pe/reference/releases/#v351).
+**Minor** release with everything from [TB Edge v3.5.1](/docs/edge/releases/#v351){: target="_blank"} and [TB PE v3.5.1](/docs/pe/reference/releases/#v351){: target="_blank"}.
 
 ## v3.5.0 (May 10, 2023) {#v35}
 
-**Major** release with everything from [TB Edge v3.5](/docs/edge/releases/#v35) and [TB PE v3.5](/docs/pe/reference/releases/#v35) with the following improvements and bug fixes:
+**Major** release with everything from [TB Edge v3.5](/docs/edge/releases/#v35){: target="_blank"} and [TB PE v3.5](/docs/pe/reference/releases/#v35){: target="_blank"} with the following improvements and bug fixes:
 
 * Edge computing support for solution templates;
 
 ## v3.4.3 (December 22, 2022)
 
-**Minor** release with everything from [TB Edge v3.4.3](/docs/edge/releases/#v343-december-22-2022) and [TB PE v3.4.3](/docs/pe/reference/releases/#v343-december-21-2022) with the following improvements and bug fixes:
+**Minor** release with everything from [TB Edge v3.4.3](/docs/edge/releases/#v343-december-22-2022){: target="_blank"} and [TB PE v3.4.3](/docs/pe/reference/releases/#v343-december-21-2022){: target="_blank"} with the following improvements and bug fixes:
 
 * Customers Hierarchy Support (partial support - only direct parents for the edge owner);
 * Real-time sync WhiteLabeling, LoginWhiteLabeling and CustomTranslation to edge;
@@ -72,13 +76,13 @@ description: ThingsBoard Edge Release Notes
 
 ## v3.4.1 (August 19, 2022)
 
-**Minor** release with everything from [TB Edge v3.4.1](/docs/edge/releases/#v341-august-19-2022) and [TB PE v3.4.1](/docs/pe/reference/releases/#v341-august-18-2022) with the following improvements and bug fixes:
+**Minor** release with everything from [TB Edge v3.4.1](/docs/edge/releases/#v341-august-19-2022){: target="_blank"} and [TB PE v3.4.1](/docs/pe/reference/releases/#v341-august-18-2022){: target="_blank"} with the following improvements and bug fixes:
 
 * Fixed startup issues and connection leaks in OPC-UA integration;
 
 ## v3.4 (July 21, 2022)
 
-Everything from [TB Edge v3.4](/docs/edge/releases/#v34-july-21-2022) and [TB PE v3.4](/docs/pe/reference/releases/#v34-july-19-2022) with the following improvements and bug fixes.
+Everything from [TB Edge v3.4](/docs/edge/releases/#v34-july-21-2022){: target="_blank"} and [TB PE v3.4](/docs/pe/reference/releases/#v34-july-19-2022){: target="_blank"} with the following improvements and bug fixes.
 
 * Integrations and converters support.
 
@@ -86,7 +90,7 @@ Everything from [TB Edge v3.4](/docs/edge/releases/#v34-july-21-2022) and [TB PE
 
 **Hot fix** release with the following bug fixes:
 * Core:
-    * Fix issue with duplicate system widget bundles that cause an error during widget loading on the dashboard [details](https://github.com/thingsboard/thingsboard-edge/issues/5)
+    * Fix issue with duplicate system widget bundles that cause an error during widget loading on the dashboard [details](https://github.com/thingsboard/thingsboard-edge/issues/5){: target="_blank"}
 
 ## v3.3.4 (March 24, 2022)
 
@@ -94,8 +98,8 @@ Minor release with the following improvements and bug fixes:
 
 **Improvements**:
 * Supports the latest features of 3.3.4.1 releases
-   * CE [3.3.4.1 release notes](https://thingsboard.io/docs/reference/releases/#v3341-march-22-2022)
-   * PE [3.3.4.1 release notes](https://thingsboard.io/docs/pe/reference/releases/#v3341-march-18-2022)
+   * CE [3.3.4.1 release notes](https://thingsboard.io/docs/reference/releases/#v3341-march-22-2022){: target="_blank"}
+   * PE [3.3.4.1 release notes](https://thingsboard.io/docs/pe/reference/releases/#v3341-march-18-2022){: target="_blank"}
 * Fixed issue with incorrect license check in case of slow or limited internet connectivity
 
 ## v3.3.3 (January 28, 2022)
@@ -104,8 +108,8 @@ Minor release with the following improvements and bug fixes:
 
 **Improvements**:
  * Supports the latest features of 3.3.3 releases
-   * CE [3.3.3 release notes](https://thingsboard.io/docs/reference/releases/#v333-january-27-2022)
-   * PE [3.3.3 release notes](https://thingsboard.io/docs/pe/reference/releases/#v333-january-27-2022)
+   * CE [3.3.3 release notes](https://thingsboard.io/docs/reference/releases/#v333-january-27-2022){: target="_blank"}
+   * PE [3.3.3 release notes](https://thingsboard.io/docs/pe/reference/releases/#v333-january-27-2022){: target="_blank"}
  * Edge uses login white labeling configuration of the owner on the cloud, and not the system
 
 **Bug fixes**:

--- a/docs/user-guide/install/edge/deb-installation.md
+++ b/docs/user-guide/install/edge/deb-installation.md
@@ -16,7 +16,7 @@ This guide provides step-by-step instructions for installing **ThingsBoard Edge*
 
 {% include templates/edge/install/prerequisites.md %}
 
-## Guided Installation Using ThingsBoard Server Pre-configured Instructions
+## Guided installation using pre-configured instructions in the Server UI
 
 {% include templates/edge/install/tb-server-pre-configured-install-instructions.md %}
 
@@ -26,7 +26,7 @@ This guide provides step-by-step instructions for installing **ThingsBoard Edge*
 
 {% include templates/install/ubuntu-java-install.md %}
 
-### Step 2. Configure ThingsBoard Edge Database
+### Step 2. Configure the ThingsBoard Edge database
 
 **ThingsBoard Edge** supports **SQL** and **hybrid** database approaches. See the architecture [page](/docs/reference/#sql-vs-nosql-vs-hybrid-database-approach){: target="_blank"} for details.
 
@@ -35,13 +35,13 @@ PostgreSQL <small>(recommended for < 5K msg/sec)</small>%,%postgresql%,%template
 Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>%,%hybrid%,%templates/edge/install/ubuntu-db-hybrid.md{% endcapture %}
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardDatabase" toggle-spec=contenttogglespec %}
 
-### Step 3. Choose Queue Service
+### Step 3. Select the Queue service
 
 **ThingsBoard Edge** can use different messaging systems and brokers for storing messages and enabling communication between its services. Choose the appropriate queue implementation based on your specific business needs:
 
 * **In Memory**: The built-in and default queue implementation. It is useful for development or proof-of-concept (PoC) environments, but is not recommended for production or any type of clustered deployments due to limited scalability.
 
-* **Kafka**: Recommended for production deployments. This queue is used in the most of ThingsBoard production environments now.
+* **Kafka**: Recommended for production deployments. This queue is used in most of the ThingsBoard production environments now.
 
 {% capture contenttogglespecqueue %}
 In Memory <small>(built-in and default)</small>%,%inmemory%,%templates/install/queue-in-memory.md%br%
@@ -50,9 +50,9 @@ Kafka in docker container <small>(recommended for on-prem, production installati
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardQueue" toggle-spec=contenttogglespecqueue %}
 
-### Step 4. ThingsBoard Edge Service Installation
+### Step 4. ThingsBoard Edge service installation
 
-Download the installation package.
+Download the installation package:
 
 ```bash
 wget https://github.com/thingsboard/thingsboard-edge/releases/download/{{ site.release.edge_tag }}/tb-edge-{{ site.release.edge_ver }}.deb
@@ -66,34 +66,33 @@ sudo dpkg -i tb-edge-{{ site.release.edge_ver }}.deb
 ```
 {: .copy-code}
 
-### Step 5. Configure ThingsBoard Edge
+### Step 5. Configure the ThingsBoard Edge
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 6. Run installation Script
+### Step 6. Run the installation Script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Start the ThingsBoard Edge Service
+### Step 7. Start the ThingsBoard Edge service
 
 ```bash
 sudo service tb-edge start
 ```
 {: .copy-code}
 
-### Step 8. Open ThingsBoard Edge UI
+### Step 8. Open the ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %} 
 
 ## Troubleshooting
 
-**ThingsBoard Edge** logs stored in the following directory:
+The **ThingsBoard Edge** logs are stored in the following directory:
  
 ```bash
 /var/log/tb-edge
 ```
-
-You can issue the following command in order to check if there are any errors on the service side:
+To check for errors on the service side, run the following command:
  
 ```bash
 cat /var/log/tb-edge/tb-edge.log | grep ERROR

--- a/docs/user-guide/install/edge/deb-installation.md
+++ b/docs/user-guide/install/edge/deb-installation.md
@@ -74,10 +74,10 @@ sudo dpkg -i tb-edge-{{ site.release.edge_ver }}.deb
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Restart ThingsBoard Edge Service
+### Step 7. Start the ThingsBoard Edge Service
 
 ```bash
-sudo service tb-edge restart
+sudo service tb-edge start
 ```
 {: .copy-code}
 

--- a/docs/user-guide/install/edge/docker.md
+++ b/docs/user-guide/install/edge/docker.md
@@ -19,7 +19,7 @@ This guide provides step-by-step instructions for running **ThingsBoard Edge** o
 ### Docker installation
 
 {% capture local-deployment %}
-**ThingsBoard** supports D**ocker Compose V2** (Docker Desktop or Compose plugin) starting from **3.4.2 release**.
+**ThingsBoard** supports **Docker Compose V2** (Docker Desktop or Compose plugin) starting from **3.4.2 release**.
 
 We strongly recommend **upgrading to and using Docker Compose V2**, as Docker no longer supports docker-compose as a standalone setup.
 {% endcapture %}
@@ -46,9 +46,9 @@ We strongly recommend **upgrading to and using Docker Compose V2**, as Docker no
 
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
-* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+* **In Memory** queue implementation is built-in and default. It is useful for development (PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now.
+* **Kafka** is recommended for production deployments. This queue is used on most of the ThingsBoard production environments now.
 
 * **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
 

--- a/docs/user-guide/install/edge/upgrade-instructions.md
+++ b/docs/user-guide/install/edge/upgrade-instructions.md
@@ -297,7 +297,7 @@ Open your server and create backup of database **tb_edge** using 'Backup Dialog'
 {% assign updateServerLink = "#upgrading-to-4.0.1" %}
 {% include templates/edge/install/compatibility-warning-version.md %}
 
-### Ubuntu/CentOS/Raspberry Pi {#ubuntucentosrpi-40}
+### Ubuntu/CentOS/Raspberry Pi {#ubuntucentosrpi-401}
 
 **NOTE**: These steps are applicable for ThingsBoard Edge 3.9.1EDGE version.
 

--- a/docs/user-guide/install/edge/upgrade-instructions.md
+++ b/docs/user-guide/install/edge/upgrade-instructions.md
@@ -12,9 +12,19 @@ description: ThingsBoard Edge upgrade instructions
         <ul>
             <li>
                 <a href="#prepare-ubuntucentosrpi" id="markdown-toc-prepare-ubuntucentos">Ubuntu/CentOS/Raspberry Pi</a>
+                <ul>
+                    <li>
+                         <a href="#restore-ubuntucentosrpi" id="markdown-toc-restore-ubuntucentos">Restore the backup (if needed)</a>
+                    </li>
+                </ul>
             </li>
             <li>
                 <a href="#prepare-docker-linux-mac" id="markdown-toc-prepare-docker-linux-mac">Docker (Linux or Mac OS)</a>
+                <ul>
+                    <li>
+                         <a href="#restore-docker-linux-mac" id="markdown-toc-restore-docker-linux-mac">Restore the backup (if needed)</a>
+                    </li>
+                </ul>
             </li>
             <li>
                 <a href="#prepare-windows" id="markdown-toc-prepare-windows">Windows</a>
@@ -209,49 +219,66 @@ description: ThingsBoard Edge upgrade instructions
 
 ## Prepare for upgrading ThingsBoard Edge {#prepare-for-upgrading}
 
+To ensure data integrity during the upgrade, back up your **ThingsBoard Edge** data. 
+
+The backup process may vary depending on your installation method (Docker, Linux service, Windows, etc.). 
+Follow the instructions below based on your environment.
+
 ### Ubuntu/CentOS/Raspberry Pi {#prepare-ubuntucentosrpi}
 
-Stop ThingsBoard Edge service:
+To ensure that no data is written to the database during the upgrade process, stop the **ThingsBoard Edge** service:
 
 ```bash
 sudo systemctl stop tb-edge
 ```
 {: .copy-code}
 
-#### Backup Database
+#### Backup database
 
-Make a backup of the database before upgrading.  
+To avoid potential data loss, create a backup of the database before upgrading.
 
-***Make sure you have enough space to place a backup of the database***  
+{% capture check-space %}
+Make sure your system has enough free space to store the backup.
+{% endcapture %}
+{% include templates/info-banner.md content=check-space %}
 
-Check database size
+Check the current size of the database:
 
 ```bash
 sudo -u postgres psql -c "SELECT pg_size_pretty( pg_database_size('tb_edge') );"
 ```
 {: .copy-code}
 
-Check free space
+Check available free disk space:
 
 ```bash
 df -h /
 ```
 {: .copy-code}
 
-If there is enough free space - make a backup.
+Create the backup (if sufficient space is available): 
 
 ```bash
 sudo -Hiu postgres pg_dump tb_edge > tb_edge.sql.bak
 ```
 {: .copy-code}
 
-Check backup file created successfully.
+Verify that the backup file was created successfully:
+
+```bash
+ls -lh tb_edge.sql.bak
+```
+{: .copy-code}
+
+### Restore the backup (if needed) {#restore-ubuntucentosrpi}
+
+{% include templates/edge/user-guide/backup/ubuntu-restore-backup.md %}
 
 ### Docker (Linux or Mac OS) {#prepare-docker-linux-mac}
 
-Set the terminal in the directory which contains the `docker-compose.yml` file and execute the following command to stop and remove currently running TB Edge container:
+Go to the directory that contains the **docker-compose.yml** file, and run the following command to stop the currently running **ThingsBoard Edge** container:
 ```
-docker compose stop && docker compose rm mytbedge -f
+docker compose stop
 ```
 {: .copy-code}
 
@@ -261,25 +288,33 @@ If you are still using **docker-compose (with a hyphen)**, it is recommended to 
 
 {% include templates/info-banner.md content=dockerComposeStandalone %}
 
-#### Backup Database Volume
+#### Backup database volume
 
-Make a copy of the database volume before upgrading:
+Before upgrading, make a **backup copy** of the database volume: 
+
 ```bash
 docker run --rm -v tb-edge-postgres-data:/source -v tb-edge-postgres-data-backup:/backup busybox sh -c "cp -a /source/. /backup"
 ```
 {: .copy-code}
 
-#### Backup Database Bind Mount Folder (deprecated)
+This command uses a temporary BusyBox container to copy all contents from the _tb-edge-postgres-data_ volume into the _tb-edge-postgres-data-backup_ volume.
 
-If you are still using Docker bind mount folders, please ensure to make a copy of the database folder before proceeding with the upgrade:
+##### Backup database bind mount folder (deprecated)
+
+If you are still using **Docker bind mount folders** (instead of named volumes), make sure to back up the database folder before proceeding with the upgrade:
+
 ```bash
 sudo cp -r ~/.mytb-edge-data/db ~/.mytb-edge-db-BACKUP
 ```
 {: .copy-code}
 
+### Restore the backup (if needed) {#restore-docker-linux-mac}
+
+{% include templates/edge/user-guide/backup/docker-restore-backup.md %}
+
 ### Windows {#prepare-windows}
 
-Stop ThingsBoard Edge service:
+Stop the **ThingsBoard Edge** service:
 
 ```text
 net stop tb-edge
@@ -288,8 +323,8 @@ net stop tb-edge
 
 #### Backup Database
 
-Launch the "pgAdmin" software and login as superuser (postgres). 
-Open your server and create backup of database **tb_edge** using 'Backup Dialog' functionality of "pgAdmin".
+* Launch **pgAdmin** and log in as the **postgres superuser**.
+* Open your server and create the backup of the **tb_edge** database using **pgAdmin**'s **"Backup Dialog"** functionality.
 
 ## Upgrading to 4.0.1EDGE {#upgrading-to-401}
 

--- a/docs/user-guide/install/pe/edge/deb-installation.md
+++ b/docs/user-guide/install/pe/edge/deb-installation.md
@@ -17,7 +17,7 @@ This guide provides step-by-step instructions for installing **ThingsBoard Edge*
 
 {% include templates/edge/install/prerequisites.md %}
 
-## Guided Installation Using ThingsBoard Server Pre-configured Instructions
+###  Guided installation using pre-configured instructions in the Server UI
 
 {% include templates/edge/install/tb-server-pre-configured-install-instructions.md %}
 
@@ -27,7 +27,7 @@ This guide provides step-by-step instructions for installing **ThingsBoard Edge*
 
 {% include templates/install/ubuntu-java-install.md %}
 
-### Step 2. Configure ThingsBoard Edge Database
+### Step 2. Configure the ThingsBoard Edge database
 
 **ThingsBoard Edge** supports **SQL** and **hybrid** database approaches. See the architecture [page](/docs/pe/reference/#sql-vs-nosql-vs-hybrid-database-approach){: target="_blank"} for details.
 
@@ -37,7 +37,7 @@ Hybrid <br>PostgreSQL+Cassandra<br><small>(recommended for > 5K msg/sec)</small>
 
 {% include content-toggle.liquid content-toggle-id="ubuntuThingsboardDatabase" toggle-spec=contenttogglespec %}
 
-### Step 3. Choose Queue Service
+### Step 3. Select the Queue service
 
 **ThingsBoard Edge** can use different messaging systems and brokers for storing messages and enabling communication between its services. Choose the appropriate queue implementation based on your specific business needs:
 
@@ -68,34 +68,33 @@ sudo dpkg -i tb-edge-{{ site.release.pe_edge_ver }}.deb
 ```
 {: .copy-code}
 
-### Step 5. Configure ThingsBoard Edge
+### Step 5. Configure the ThingsBoard Edge
 
 {% include templates/edge/install/linux-configure-edge.md %}
 
-### Step 6. Run installation script
+### Step 6. Run the installation script
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Start the ThingsBoard Edge Service
+### Step 7. Start the ThingsBoard Edge service
 
 ```bash
 sudo service tb-edge start
 ```
 {: .copy-code}
 
-### Step 8. Open ThingsBoard Edge UI
+### Step 8. Open the ThingsBoard Edge UI
 
 {% include templates/edge/install/open-edge-ui.md %} 
 
 ## Troubleshooting
 
-ThingsBoard Edge logs stored in the following directory:
+The **ThingsBoard Edge** logs are stored in the following directory:
  
 ```bash
 /var/log/tb-edge
 ```
-
-You can issue the following command in order to check if there are any errors on the service side:
+To check for errors on the service side, run the following command:
  
 ```bash
 cat /var/log/tb-edge/tb-edge.log | grep ERROR

--- a/docs/user-guide/install/pe/edge/deb-installation.md
+++ b/docs/user-guide/install/pe/edge/deb-installation.md
@@ -76,10 +76,10 @@ sudo dpkg -i tb-edge-{{ site.release.pe_edge_ver }}.deb
 
 {% include templates/edge/install/run-edge-install.md %} 
 
-### Step 7. Restart ThingsBoard Edge Service
+### Step 7. Start the ThingsBoard Edge Service
 
 ```bash
-sudo service tb-edge restart
+sudo service tb-edge start
 ```
 {: .copy-code}
 

--- a/docs/user-guide/install/pe/edge/docker.md
+++ b/docs/user-guide/install/pe/edge/docker.md
@@ -49,9 +49,9 @@ We strongly recommend **upgrading to and using Docker Compose V2**, as Docker no
 
 **ThingsBoard Edge** is able to use different messaging systems/brokers for storing the messages and communication between ThingsBoard services. How to choose the right queue implementation?
 
-* **In Memory** queue implementation is built-in and default. It is useful for development(PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
+* **In Memory** queue implementation is built-in and default. It is useful for development (PoC) environments and is not suitable for production deployments or any sort of cluster deployments.
 
-* **Kafka** is recommended for production deployments. This queue is used on the most of ThingsBoard production environments now.
+* **Kafka** is recommended for production deployments. This queue is used on most of the ThingsBoard production environments now.
 
 * **Hybrid** implementation combines PostgreSQL and Cassandra databases with Kafka queue service. It is recommended if you plan to manage 1M+ devices in production or handle high data ingestion rate (more than 5000 msg/sec).
 

--- a/docs/user-guide/install/pe/edge/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/edge/upgrade-instructions.md
@@ -11,10 +11,20 @@ description: ThingsBoard PE Edge upgrade instructions
         <a href="#prepare-for-upgrading" id="markdown-toc-prepare-for-upgrading">Prepare for upgrading ThingsBoard PE Edge</a>
         <ul>
             <li>
-                <a href="#prepare-ubuntucentosrpi" id="markdown-toc-prepare-ubuntucentos">Ubuntu/CentOS/Raspberry Pi</a> 
+                <a href="#prepare-ubuntucentosrpi" id="markdown-toc-prepare-ubuntucentos">Ubuntu/CentOS/Raspberry Pi</a>
+                <ul>
+                    <li>
+                         <a href="#restore-ubuntucentosrpi" id="markdown-toc-restore-ubuntucentos">Restore the backup (if needed)</a>
+                    </li>
+                </ul>
             </li>
             <li>
                 <a href="#prepare-docker-linux-mac" id="markdown-toc-prepare-docker-linux-mac">Docker (Linux or Mac OS)</a>
+                <ul>
+                    <li>
+                         <a href="#restore-docker-linux-mac" id="markdown-toc-restore-docker-linux-mac">Restore the backup (if needed)</a>
+                    </li>
+                </ul>
             </li>
             <li>
                 <a href="#prepare-windows" id="markdown-toc-prepare-windows">Windows</a>
@@ -210,9 +220,14 @@ description: ThingsBoard PE Edge upgrade instructions
 
 ## Prepare for upgrading ThingsBoard Edge {#prepare-for-upgrading}
 
+To ensure data integrity during the upgrade, back up your **ThingsBoard Edge Professional Edition** data.
+
+The backup process may vary depending on your installation method (Docker, Linux service, Windows, etc.).
+Follow the instructions below based on your environment.
+
 ### Ubuntu/CentOS/Raspberry Pi {#prepare-ubuntucentosrpi}
 
-Stop ThingsBoard Edge service:
+To ensure that no data is written to the database during the upgrade process, stop the **ThingsBoard Edge** service:
 
 ```bash
 sudo systemctl stop tb-edge
@@ -221,38 +236,51 @@ sudo systemctl stop tb-edge
 
 #### Backup Database
 
-Make a backup of the database before upgrading.  
+To avoid potential data loss, create a backup of the database before upgrading.
 
-***Make sure you have enough space to place a backup of the database***  
+{% capture check-space %}
+Make sure your system has enough free space to store the backup.
+{% endcapture %}
+{% include templates/info-banner.md content=check-space %}
 
-Check database size
+Check the current size of the database:
 
 ```bash
 sudo -u postgres psql -c "SELECT pg_size_pretty( pg_database_size('tb_edge') );"
 ```
 {: .copy-code}
 
-Check free space
+Check available free disk space:
 
 ```bash
 df -h /
 ```
 {: .copy-code}
 
-If there is enough free space - make a backup.
+Create the backup (if sufficient space is available):
 
 ```bash
 sudo -Hiu postgres pg_dump tb_edge > tb_edge.sql.bak
 ```
 {: .copy-code}
 
-Check backup file created successfully.
+Verify that the backup file was created successfully:
+
+```bash
+ls -lh tb_edge.sql.bak
+```
+{: .copy-code}
+
+### Restore the backup (if needed) {#restore-ubuntucentosrpi}
+
+{% include templates/edge/user-guide/backup/ubuntu-restore-backup.md %}
 
 ### Docker (Linux or Mac OS) {#prepare-docker-linux-mac}
 
-Set the terminal in the directory which contains the `docker-compose.yml` file and execute the following command to stop and remove currently running TB Edge container:
+Go to the directory that contains the **docker-compose.yml** file, and run the following command to stop the currently running **ThingsBoard Edge PE** container:
+
 ```
-docker compose stop && docker compose rm mytbedge -f
+docker compose stop
 ```
 {: .copy-code}
 
@@ -262,22 +290,29 @@ If you are still using **docker-compose (with a hyphen)**, it is recommended to 
 
 {% include templates/info-banner.md content=dockerComposeStandalone %}
 
-#### Backup Database Volume
+#### Backup database volume
 
-Make a copy of the database volume before upgrading:
+Before upgrading, make a **backup copy** of the database volume:
+
 ```bash
 docker run --rm -v tb-edge-postgres-data:/source -v tb-edge-postgres-data-backup:/backup busybox sh -c "cp -a /source/. /backup"
 ```
 {: .copy-code}
 
+This command uses a temporary BusyBox container to copy all contents from the _tb-edge-postgres-data_ volume into the _tb-edge-postgres-data-backup_ volume.
 
-#### Backup Database Bind Mount Folder (deprecated)
+##### Backup database bind mount folder (deprecated)
 
-If you are still using Docker bind mount folders, please ensure to make a copy of the database folder before proceeding with the upgrade:
-```
+If you are still using **Docker bind mount folders** (instead of named volumes), make sure to back up the database folder before proceeding with the upgrade:
+
+```bash
 sudo cp -r ~/.mytb-edge-data/db ~/.mytb-edge-db-BACKUP
 ```
 {: .copy-code}
+
+### Restore the backup (if needed) {#restore-docker-linux-mac}
+
+{% include templates/edge/user-guide/backup/docker-restore-backup.md %}
 
 ### Windows {#prepare-windows}
 
@@ -290,8 +325,8 @@ net stop tb-edge
 
 #### Backup Database
 
-Launch the "pgAdmin" software and login as superuser (postgres). 
-Open your server and create backup of database **tb_edge** using 'Backup Dialog' functionality of "pgAdmin".
+* Launch **pgAdmin** and log in as the **postgres superuser**.
+* Open your server and create the backup of the **tb_edge** database using **pgAdmin**'s **"Backup Dialog"** functionality.
 
 ## Upgrading to 4.0.1EDGEPE {#upgrading-to-401}
 


### PR DESCRIPTION
For CE and PE 
- minor corrections for Docker (linux), Ubuntu and Cluster instructions
- upgrade instructions update:
    - added restore backup for docker and ubuntu
    - improved upgrade instructions for docker
- added 4.0.1 release in the roadmaps