### PR TITLE
Added a links to a video guides

### DIFF
--- a/_includes/docs/pe/user-guide/custom-menu.md
+++ b/_includes/docs/pe/user-guide/custom-menu.md
@@ -16,6 +16,13 @@ Menu customization options:
 
 - **Personalized settings**: The menu can be customized individually for each tenant, customer, or their users, providing an additional level of personalization.
 
+&nbsp;
+<div id="video">  
+    <div id="video_wrapper">
+        <iframe src="https://www.youtube.com/embed/U69PLwRoWyI" frameborder="0" allowfullscreen></iframe>
+    </div>
+</div>
+
 ## Add custom menu
 
 Before adding a custom menu in ThingsBoard, it is important to define the scope of its application, depending on who the end user is: Tenant or Customer.

--- a/_includes/docs/pe/user-guide/custom-translation.md
+++ b/_includes/docs/pe/user-guide/custom-translation.md
@@ -18,15 +18,6 @@ However, for more specific requirements, the **Custom translation** feature is a
 - [Modify or extend](#modify-current-translation) existing translations;
 - Use [custom translations](#custom-translation) for dashboard titles, widgets, devices, telemetry keys, and other interface elements.
 
-Go to the "**White labeling**" page and open the "**Custom translation**" tab. Here you&#39;ll see a list of available languages and their translation progress indicated in percentages.
-
-![image](/images/user-guide/custom-translation/main-page-1-pe.png)
-
-{% capture difference %}
-**Please note:** The initial list of custom translations is created by the system administrator. A tenant cannot delete the system&#39;s custom translations but can make changes to them and add new translations.
-{% endcapture %}
-{% include templates/info-banner.md content=difference %}
-
 ## Change platform language
 
 To change the language of your account, follow these steps:
@@ -87,6 +78,15 @@ As you continue adding more translations, the progress indicator will automatica
 {% include images-gallery.liquid imageCollection=addNewLanguagePE %}
 
 ## Translation editor
+
+Go to the "**White labeling**" page and open the "**Custom translation**" tab. Here you&#39;ll see a list of available languages and their translation progress indicated in percentages.
+
+![image](/images/user-guide/custom-translation/main-page-1-pe.png)
+
+{% capture difference %}
+**Please note:** The initial list of custom translations is created by the system administrator. A tenant cannot delete the system&#39;s custom translations but can make changes to them and add new translations.
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
 
 You can modify or extend the translation for any language. To do this, click the "pencil" icon next to the language you want to edit.
 
@@ -232,6 +232,15 @@ Example of the translation map:
 ## Custom translation
 
 You can provide custom translations for new custom menu items or individual UI elements (such as dashboard titles, widget names, device names, data keys, etc.) using translation keys in the **i18n** format.
+
+&nbsp;
+<div id="video">  
+    <div id="video_wrapper">
+        <iframe src="https://www.youtube.com/embed/NQ92phUUsYM" frameborder="0" allowfullscreen></iframe>
+    </div>
+</div>
+
+<br>
 
 To add custom translations:
 

--- a/_includes/docs/pe/user-guide/white-labeling.md
+++ b/_includes/docs/pe/user-guide/white-labeling.md
@@ -18,6 +18,13 @@ But only Tenant Administrator are able to set up customer email templates to int
 By default, the Customer inherits the Tenant UI configuration. But the Customer Administrator are able to set up their own White Labeling configuration.
 {% endif %}
 
+&nbsp;
+<div id="video">  
+    <div id="video_wrapper">
+        <iframe src="https://www.youtube.com/embed/jSXuHj3lbG0" frameborder="0" allowfullscreen></iframe>
+    </div>
+</div>
+
 ## White labeling settings
 
 To configure your company or product logo and color scheme, go to the "White labeling" page.


### PR DESCRIPTION
Video tutorial links have been added for the following guides:
- White labeling
- Custom translation
- Custom menu

![Screenshot from 2025-05-29 14-55-41](https://github.com/user-attachments/assets/5b3d4e2c-d7d0-4e95-a6aa-4e42af2d5329)

![Screenshot from 2025-05-29 14-56-00](https://github.com/user-attachments/assets/d4bb2f5f-3201-4e10-b1a1-154360ad3c57)

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
