### PR TITLE
Removed exit code check for windows docker guide

### DIFF
--- a/docs/user-guide/install/docker-windows.md
+++ b/docs/user-guide/install/docker-windows.md
@@ -64,7 +64,7 @@ Environment variables:
 Bring up all containers in detached mode, then follow the ThingsBoard logs (use PowerShell for the command below):
 
 ```bash
-docker compose up -d; if ($?) {docker compose logs -f thingsboard-ce}
+docker compose up -d; docker compose logs -f thingsboard-ce
 ```
 
 After executing this command you can open `http://{your-host-ip}:8080` in you browser (for ex. `http://localhost:8080`). You should see ThingsBoard login page.

--- a/docs/user-guide/install/pe/docker-windows.md
+++ b/docs/user-guide/install/pe/docker-windows.md
@@ -70,7 +70,7 @@ Environment variables:
 Bring up all containers in detached mode, then follow the ThingsBoard logs (use PowerShell for the command below):
 
 ```bash
-docker compose up -d; if ($?) {docker compose logs -f thingsboard-pe}
+docker compose up -d; docker compose logs -f thingsboard-pe
 ```
 {: .copy-code}
 


### PR DESCRIPTION
## PR description

The documentation has been updated for the Windows Docker guide.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
