### PR TITLE
JDK headless

### DIFF
--- a/_includes/templates/edge/install/cassandra-rhel-install.md
+++ b/_includes/templates/edge/install/cassandra-rhel-install.md
@@ -1,6 +1,6 @@
 In order to run Cassandra, install **Java 11**:
 ```bash
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-11-jdk-headless
 ```
 {: .copy-code}
 

--- a/_includes/templates/edge/install/cassandra-ubuntu-install.md
+++ b/_includes/templates/edge/install/cassandra-ubuntu-install.md
@@ -14,7 +14,7 @@ sudo apt-get install cassandra-tools
 In order to run Cassandra, install **Java 11**.
 
 ```bash
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-11-jdk-headless
 ```
 {: .copy-code}
 

--- a/_includes/templates/install/rhel-java-install.md
+++ b/_includes/templates/install/rhel-java-install.md
@@ -1,7 +1,7 @@
 ThingsBoard service is running on Java 17. Follow this instructions to install OpenJDK 17:
 
 ```bash
-sudo dnf install java-17-openjdk
+sudo dnf install java-17-openjdk-headless
 ```
 {: .copy-code}
 

--- a/_includes/templates/install/ubuntu-java-install.md
+++ b/_includes/templates/install/ubuntu-java-install.md
@@ -1,7 +1,7 @@
 ThingsBoard service is running on Java 17. To install OpenJDK 17, follow these instructions
 
 ```bash
-sudo apt update && sudo apt install openjdk-17-jdk
+sudo apt update && sudo apt install openjdk-17-jdk-headless
 ```
 {: .copy-code}
 

--- a/docs/mqtt-broker/install/building-from-source.md
+++ b/docs/mqtt-broker/install/building-from-source.md
@@ -20,7 +20,7 @@ TBMQ is build using Java 17. Follow these instructions to install OpenJDK 17:
 
 ```bash
 sudo apt update
-sudo apt install openjdk-17-jdk
+sudo apt install openjdk-17-jdk-headless
 ```
 {: .copy-code}
 

--- a/docs/user-guide/install/resources/java-centos-installation.sh
+++ b/docs/user-guide/install/resources/java-centos-installation.sh
@@ -1,1 +1,1 @@
-sudo yum install java-11-openjdk
+sudo yum install java-11-openjdk-headless

--- a/docs/user-guide/install/resources/java-ubuntu-installation.sh
+++ b/docs/user-guide/install/resources/java-ubuntu-installation.sh
@@ -1,2 +1,2 @@
 sudo apt update
-sudo apt install openjdk-11-jdk
+sudo apt install openjdk-11-jdk-headless


### PR DESCRIPTION
## PR description

[openjdk-11-jdk-headless](https://github.com/thingsboard/thingsboard.github.io/commit/cb6be4b2a69ff4bb45419cf13557f1ba05a776a5) 

[openjdk-17-jdk-headless](https://github.com/thingsboard/thingsboard.github.io/commit/7e32dc292a975f2e58474c9298779f4b6102c942)

[dnf install java-17-openjdk-headless](https://github.com/thingsboard/thingsboard.github.io/pull/2102/commits/4d6cef66a37ed4db440e268a024e8477e601331c) 

[yum install java-11-openjdk-headless](https://github.com/thingsboard/thingsboard.github.io/pull/2102/commits/aa3d7cffa6e6458f50068d0bd0321e3b4e3a60ea)

Windows install with no change because it references to JDK web page install

Recheck across all over the project

![image](https://github.com/user-attachments/assets/f5e551b9-0a85-4edd-b365-52f7caebdd84)

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
