### PR TITLE
Fixed duplicate headers on pages

### DIFF
--- a/docs/samples/smartico/gas-meter-lorawan/Gas_Meter_LoRaWAN.md
+++ b/docs/samples/smartico/gas-meter-lorawan/Gas_Meter_LoRaWAN.md
@@ -8,13 +8,14 @@ hidetoc: "true"
 * TOC
 {:toc}
 
-# Ultrasonic Residential Smart Gas Meter LoRaWAN “Smartico G-1.6” telemetry upload
 ## Introduction
+
 Residential gas meters “Smartico” are produced by the size range G-1.6, G-2.5, G-4, G-6 and are used to measure the volume of used natural and liquefied gas, with conversion to standard reference at a temperature of 20 °C. The meter is made in a compact design, which has no moving mechanical parts and allows mounting in a confined space. The meter measurement system provides high-precision metrological characteristics. The meter provides the possibility visual control and wireless data transmission by license-free frequency range using LoRaWAN technology.  The figure shows a dashboard with processed telemetry results.
 
 ![image](/images/samples/smartico/gas-meter-lorawan/MainDashboard.png)
 
 ## Prerequisites
+
 LoRaWAN technology is used to transfer data from the Gas Meter G-1.6 to the ThingsBoard platform. This is the wireless communication technology that allows small amounts of data to be exchanged over a long distance. First of all, you need to configure the LoRaWAN server and make sure that data from the device goes to the server. This guide uses [ChirpStack open-source LoRaWAN Network Server](https://www.chirpstack.io/application-server/). 
 After finishing the server configuration on the Applications page, an entry with the device type should appear in the table.
 

--- a/docs/samples/smartico/gas-valve-lorawan/Gas_Valve_LoRaWAN.md
+++ b/docs/samples/smartico/gas-valve-lorawan/Gas_Valve_LoRaWAN.md
@@ -1,20 +1,21 @@
 ---
 layout: docwithnav
-title: Gas Shutoff Valve LoRaWAN “Smartico V-LR” telemetry upload
-description: ThingsBoard IoT Platform sample for valve state data upload over MQTT using Gas Shutoff Valve LoRaWAN “Smartico V-LR”.
+title: Gas Shutoff Valve LoRaWAN "Smartico V-LR" telemetry upload
+description: ThingsBoard IoT Platform sample for valve state data upload over MQTT using Gas Shutoff Valve LoRaWAN "Smartico V-LR".
 hidetoc: "true"
 ---
 
 * TOC
 {:toc}
 
-# Gas Shutoff Valve LoRaWAN “Smartico V-LR” telemetry upload
 ## Introduction
+
 The Gas Shutoff Valve LoRaWAN “Smartico V-LR” was designed for remotely shut off the gas supply in the low pressure gas network. The shut-off valve was made with autonomous power supply. It has a special valve activation mechanism that allows safe recovery of gas supply. Places of installation of protective seals are provided to prevent unauthorized access to the power source and exclude the possibility of dismantling the valve from the connecting gas pipeline. The figure shows a dashboard with processed telemetry results.
 
 ![image](/images/samples/smartico/gas-valve-lorawan/MainDash.png)
 
 ## Prerequisites
+
 LoRaWAN technology is used to transfer data from the Gas Valve V-LR to the ThingsBoard platform. This is the wireless communication technology that allows small amounts of data to be exchanged over a long distance. First of all, you need to configure the LoRaWAN server and make sure that data from the device goes to the server. This guide uses [ChirpStack open-source LoRaWAN Network Server](https://www.chirpstack.io/application-server/). 
 After finishing the server configuration on the Applications page, an entry with the device type should appear in the table.
 

--- a/docs/samples/smartico/leaks-detector-lorawan/Leaks_Detector_LoRaWAN.md
+++ b/docs/samples/smartico/leaks-detector-lorawan/Leaks_Detector_LoRaWAN.md
@@ -1,20 +1,21 @@
 ---
 layout: docwithnav
-title: Leaks Detector LoRaWAN “Smartico L2-LR” telemetry upload
-description: ThingsBoard IoT Platform sample for leaks data upload over MQTT using Leaks Detector LoRaWAN “Smartico L2-LR”.
+title: Leaks Detector LoRaWAN "Smartico L2-LR" telemetry upload
+description: ThingsBoard IoT Platform sample for leaks data upload over MQTT using Leaks Detector LoRaWAN "Smartico L2-LR".
 hidetoc: "true"
 ---
 
 * TOC
 {:toc}
 
-# Leaks Detector LoRaWAN “Smartico L2-LR” telemetry upload
 ## Introduction
+
 The device Leaks Detector LoRaWAN “Smartico L2-LR” is used in various fields of industry, utilities and automation for remote data collection, leaks detection and data transmission via LoRaWAN networks. The device implements two zone control using passive leak sensors, which provide high energy efficiency solutions. The design of the sensor in a waterproof housing allows external use. The figure shows a dashboard with processed telemetry results.
 
 ![image](/images/samples/smartico/leaks-detector-lorawan/mainDash.PNG)
 
 ## Prerequisites
+
 LoRaWAN technology is used to transfer data from the Leaks Detector L2-LR to the ThingsBoard platform. This is the wireless communication technology that allows small amounts of data to be exchanged over a long distance. First of all, you need to configure the LoRaWAN server and make sure that data from the device goes to the server.  This guide uses [ChirpStack open-source LoRaWAN Network Server](https://www.chirpstack.io/application-server/). 
 After finishing the server configuration on the Applications page, an entry with the device type should appear in the table.
 

--- a/docs/samples/smartico/pulse-sensor-lorawan/Pulse_Sensor_LoRaWAN.md
+++ b/docs/samples/smartico/pulse-sensor-lorawan/Pulse_Sensor_LoRaWAN.md
@@ -8,9 +8,8 @@ hidetoc: "true"
 * TOC
 {:toc}
 
-# Water meter Pulse Sensor LoRaWAN "Smartico P22-LR" telemetry upload
 ## Introduction
-The device Pulse Sensor LoRaWAN “Smartico P22-LR” is used in various fields of industry, utilities and automation for remote data collection and transmission via LoRaWAN networks. The device has two universal pulse inputs with control of the integrity of the communication. In this example, two water meters are connected to the device. The figure shows a dashboard with processed telemetry results.
+The device Pulse Sensor LoRaWAN "Smartico P22-LR" is used in various fields of industry, utilities and automation for remote data collection and transmission via LoRaWAN networks. The device has two universal pulse inputs with control of the integrity of the communication. In this example, two water meters are connected to the device. The figure shows a dashboard with processed telemetry results.
 
 ![image](/images/samples/smartico/pulse-sensor-lorawan/dashboard.png)
 

--- a/docs/samples/smartico/wm-bus-lorawan/wMBus_Reader_LoRaWAN.md
+++ b/docs/samples/smartico/wm-bus-lorawan/wMBus_Reader_LoRaWAN.md
@@ -8,13 +8,14 @@ hidetoc: "true"
 * TOC
 {:toc}
 
-# Water meter wM-Bus Reader LoRaWAN "Smartico WM-LR" telemetry upload
 ## Introduction
+
 The device wM-Bus Reader LoRaWAN “Smartico WM-LR” is used in various fields of industry, utilities and automation for remote data collection from gas, water, electricity and heat meters with the help of the wM-Bus protocol and data transmission via LoRaWAN networks. Additionally, the device has an input for wired connection to the digital interface of Kamstrup meters as a standard. This input can also be used to count pulses. The design of the sensor in a waterproof housing allows external use. The sensor’s compact size allows installation in confined spaces, and special adapters provide reliable mounting to a pipe or a flat surface without opening the case. In this example, four water meters are connected to the device. The figure shows a dashboard with processed telemetry results.
 
 ![image](/images/samples/smartico/wm-bus-lorawan/mainDashboard.PNG)
 
 ## Prerequisites
+
 LoRaWAN technology is used to transfer data from the wM-Bus Reader WM-LR to the ThingsBoard platform. This is the wireless communication technology that allows small amounts of data to be exchanged over a long distance. First of all, you need to configure the LoRaWAN server and make sure that data from the device goes to the server. This guide uses [ChirpStack open-source LoRaWAN Network Server](https://www.chirpstack.io/application-server/). 
 After finishing the server configuration on the Applications page, an entry with the device type should appear in the table.
 


### PR DESCRIPTION
https://thingsboard-portal.atlassian.net/browse/PROD-6368

Fixed duplicate headers on pages:

https://thingsboard.io/docs/samples/smartico/gas-meter-lorawan/Gas_Meter_LoRaWAN/ 
https://thingsboard.io/docs/samples/smartico/gas-valve-lorawan/Gas_Valve_LoRaWAN/
https://thingsboard.io/docs/samples/smartico/leaks-detector-lorawan/Leaks_Detector_LoRaWAN/ 
https://thingsboard.io/docs/samples/smartico/pulse-sensor-lorawan/Pulse_Sensor_LoRaWAN/

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
