### PR TITLE
Added migration guide for old Thingsboard PE docker-compose deployment files.

### DIFF
--- a/docs/user-guide/install/pe/docker-windows.md
+++ b/docs/user-guide/install/pe/docker-windows.md
@@ -123,7 +123,7 @@ docker compose up -d
 When a new PE release is available, follow these steps to update your installation without losing data:
 
 {% capture old_manifests_info %}
-**If you upgrade using previous version of manifests make sure to change image `thingsboard/tb-pe` to `thingsboard/tb-pe-node` and append `tb-web-report` service to the docker-compose.yml file explicitly**
+**If you upgrade using previous version of manifests make sure to follow these steps first** [instructions](/docs/user-guide/install/pe/old-docker-migrate-windows/)
 {% endcapture %}
 {% include templates/info-banner.md content=old_manifests_info %}
 

--- a/docs/user-guide/install/pe/docker.md
+++ b/docs/user-guide/install/pe/docker.md
@@ -125,7 +125,7 @@ docker compose up -d
 When a new PE release is available, follow these steps to update your installation without losing data:
 
 {% capture old_manifests_info %}
-**If you upgrade using previous version of manifests make sure to change image `thingsboard/tb-pe` to `thingsboard/tb-pe-node` and append `tb-web-report` service to the docker-compose.yml file explicitly**
+**If you upgrade using previous version of manifests make sure to follow these steps first** [instructions](/docs/user-guide/install/pe/old-docker-migrate/)
 {% endcapture %}
 {% include templates/info-banner.md content=old_manifests_info %}
 

--- a/docs/user-guide/install/pe/old-docker-migrate-windows.md
+++ b/docs/user-guide/install/pe/old-docker-migrate-windows.md
@@ -4,7 +4,6 @@ assignees:
 - ashvayka
 title: Migrate from old Docker deployment files
 description: Migrate from old Docker deployment files
-redirect_from: "/docs/pe/user-guide/install/docker/"
 ---
 
 * TOC

--- a/docs/user-guide/install/pe/old-docker-migrate-windows.md
+++ b/docs/user-guide/install/pe/old-docker-migrate-windows.md
@@ -1,0 +1,120 @@
+---
+layout: docwithnav-pe
+assignees:
+- ashvayka
+title: Migrate from old Docker deployment files
+description: Migrate from old Docker deployment files
+redirect_from: "/docs/pe/user-guide/install/docker/"
+---
+
+* TOC
+{:toc}
+
+
+This guide will help you to move from the old deployment files for Docker installation using deprecated image `thingsboard/tb-pe` and volume bindings instead of local volumes. 
+This guide covers standalone ThingsBoard PE installation. 
+
+## Why deployment files were changed? 
+
+- they used deprecated image `thingsboard/tb-pe` without arm64 architecture support.
+- data was persited in local folders with specific ownerships instead of Docker volumes mechanism
+
+## Who needs this guide?
+
+Customers who has docker compose file as below or similar:
+
+```yml
+version: '3.0'
+services:
+  mytbpe:
+    restart: always
+    image: "thingsboard/tb-pe:{{ site.release.pe_full_ver }}"
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "7070:7070"
+      - "5683-5688:5683-5688/udp"
+    environment:
+      TB_QUEUE_TYPE: in-memory
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/thingsboard
+      TB_LICENSE_SECRET: PUT_YOUR_LICENSE_SECRET_HERE
+      TB_LICENSE_INSTANCE_DATA_FILE: /data/license.data
+    volumes:
+      - mytbpe-data:/data
+      - mytbpe-logs:/var/log/thingsboard
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+    - "5432"
+    environment:
+      POSTGRES_DB: thingsboard
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - mytbpe-data-db:/var/lib/postgresql/data
+volumes:
+  mytbpe-data:
+    external: true
+  mytbpe-logs:
+    external: true
+  mytbpe-data-db:
+    external: true
+```
+
+## Move Postgres data to Docker volume
+
+Create a named Docker volume:
+
+```bash
+docker volume create --name tb-postgres-data
+```
+{: .copy-code}
+
+Run container with attached volumes to copy data from folder to newly created volume
+
+```bash
+docker run --rm -v mytbpe-data-db:/source -v tb-postgres-data:/destination alpine sh -c "cp -rp /source/* /destination/"
+```
+{: .copy-code}
+
+{% capture old_postgres_info %}
+**Note that previously we have PostgreSQL 15 image in our docker compose, which is replaced with PostgreSQL 16 now.**
+**In order to start Postgres DB container you need either use `postgres:15` image in new deployment files or upgrade database files**
+{% endcapture %}
+{% include templates/info-banner.md content=old_postgres_info %}
+
+## Move License data to Docker volume
+
+Create a named Docker volume:
+
+```bash
+docker volume create --name tb-pe-license-data
+```
+{: .copy-code}
+
+Run container with attached volumes to copy data from folder to newly created volume:
+
+```bash
+docker run --rm -v mytbpe-data:/source -v tb-pe-license-data:/destination alpine sh -c "cp -a /source/license.data /destination/ && chown 799:799 /destination/license.data"
+```
+{: .copy-code}
+
+## Move to new deployment files
+
+Open `docker-compose.yml` file with text editor:
+
+```bash
+notepad docker-compose.yml
+```
+{: .copy-code}
+
+Copy current Docker Compose [manifest](https://thingsboard.io/docs/user-guide/install/pe/docker-windows/#step-2-choose-thingsboard-queue-service) and replace old one with current manifest. Replace Postgres docker image if needed. 
+
+{% capture image_tags %}
+**Make sure that `thingsboard/tb-pe-node` and `thingsboard/tb-web-report` have the same tag as your previous manifests**
+{% endcapture %}
+{% include templates/info-banner.md content=image_tags %}
+
+Don't forget to replace license key in the environment variables section.
+
+After data is moved to the docker volumes and `docker-compose.yml` file have the same structure as the installation example - you can proceed with [upgrade](https://thingsboard.io/docs/user-guide/install/pe/docker-windows/#upgrading) of the ThingsBoard. 

--- a/docs/user-guide/install/pe/old-docker-migrate.md
+++ b/docs/user-guide/install/pe/old-docker-migrate.md
@@ -4,7 +4,6 @@ assignees:
 - ashvayka
 title: Migrate from old Docker deployment files
 description: Migrate from old Docker deployment files
-redirect_from: "/docs/pe/user-guide/install/docker/"
 ---
 
 * TOC

--- a/docs/user-guide/install/pe/old-docker-migrate.md
+++ b/docs/user-guide/install/pe/old-docker-migrate.md
@@ -1,0 +1,113 @@
+---
+layout: docwithnav-pe
+assignees:
+- ashvayka
+title: Migrate from old Docker deployment files
+description: Migrate from old Docker deployment files
+redirect_from: "/docs/pe/user-guide/install/docker/"
+---
+
+* TOC
+{:toc}
+
+
+This guide will help you to move from the old deployment files for Docker installation using deprecated image `thingsboard/tb-pe` and volume bindings instead of local volumes. 
+This guide covers standalone ThingsBoard PE installation. 
+
+## Why deployment files were changed? 
+
+- they used deprecated image `thingsboard/tb-pe` without arm64 architecture support.
+- data was persited in local folders with specific ownerships instead of Docker volumes mechanism
+
+## Who needs this guide?
+
+Customers who has docker compose file as below or similar:
+
+```yml
+version: '3.0'
+services:
+  mytbpe:
+    restart: always
+    image: "thingsboard/tb-pe:3.9.1PE"
+    ports:
+      - "8080:8080"
+      - "1883:1883"
+      - "7070:7070"
+      - "5683-5688:5683-5688/udp"
+    environment:
+      TB_QUEUE_TYPE: in-memory
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/thingsboard
+      TB_LICENSE_SECRET: PUT_YOUR_LICENSE_SECRET_HERE
+      TB_LICENSE_INSTANCE_DATA_FILE: /data/license.data
+    volumes:
+      - ~/.mytbpe-data:/data
+      - ~/.mytbpe-logs:/var/log/thingsboard
+  postgres:
+    restart: always
+    image: "postgres:15"
+    ports:
+    - "5432"
+    environment:
+      POSTGRES_DB: thingsboard
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - ~/.mytbpe-data/db:/var/lib/postgresql/data
+```
+
+## Move Postgres data to Docker volume
+
+Create a named Docker volume:
+
+```bash
+docker volume create --name tb-postgres-data
+```
+{: .copy-code}
+
+Run container with attached volumes to copy data from folder to newly created volume
+
+```bash
+docker run --rm -v ~/.mytbpe-data/db:/source -v tb-postgres-data:/destination alpine sh -c "cp -rp /source/* /destination/"
+```
+{: .copy-code}
+
+{% capture old_postgres_info %}
+**Note that previously we have PostgreSQL 15 image in our docker compose, which is replaced with PostgreSQL 16 now.**
+**In order to start Postgres DB container you need either use `postgres:15` image in new deployment files or upgrade database files**
+{% endcapture %}
+{% include templates/info-banner.md content=old_postgres_info %}
+
+## Move License data to Docker volume
+
+Create a named Docker volume:
+
+```bash
+docker volume create --name tb-pe-license-data
+```
+{: .copy-code}
+
+Run container with attached volumes to copy data from folder to newly created volume:
+
+```bash
+docker run --rm -v ~/.mytbpe-data/:/source -v tb-pe-license-data:/destination alpine sh -c "cp -a /source/license.data /destination/ && chown 799:799 /destination/license.data"
+```
+{: .copy-code}
+
+## Move to new deployment files
+
+Open `docker-compose.yml` file with text editor:
+
+```bash
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Copy current Docker Compose [manifest](https://thingsboard.io/docs/user-guide/install/pe/docker/#step-2-choose-thingsboard-queue-service) and replace old one with current manifest. Replace Postgres docker image if needed. 
+
+{% capture image_tags %}
+**Make sure that `thingsboard/tb-pe-node` and `thingsboard/tb-web-report` have the same tag as your previous manifests**
+{% endcapture %}
+{% include templates/info-banner.md content=image_tags %}
+
+Don't forget to replace license key in the environment variables section.
+
+After data is moved to the docker volumes and `docker-compose.yml` file have the same structure as the installation example - you can proceed with [upgrade](https://thingsboard.io/docs/user-guide/install/pe/docker/#upgrading) of the ThingsBoard. 


### PR DESCRIPTION
## PR description

The documentation has been updated for Docker monolith guides (Linux, macOS, and Windows). Added new pages with steps on how to move from old directory binds and external volumes to the current deployment files structure. 

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
