### PR TITLE
add Java required package for CentOS

### DIFF
--- a/_includes/templates/install/rhel-java-install.md
+++ b/_includes/templates/install/rhel-java-install.md
@@ -1,7 +1,7 @@
 ThingsBoard service is running on Java 17. Follow this instructions to install OpenJDK 17:
 
 ```bash
-sudo dnf install java-17-openjdk
+sudo dnf update && sudo dnf install java-17-openjdk-headless java-17-openjdk-devel
 ```
 {: .copy-code}
 


### PR DESCRIPTION
## Java installation on CentOS

The installation instructions for CentOS/RHEL have been updated to add the required Java package. 