### PR TITLE
fix download link for 4.1pe/4.0.2pe windows upgrades

### DIFF
--- a/docs/user-guide/install/pe/upgrade-instructions.md
+++ b/docs/user-guide/install/pe/upgrade-instructions.md
@@ -376,7 +376,7 @@ These upgrade steps are applicable for ThingsBoard version 3.9.xPE and ThingsBoa
 
 #### ThingsBoard PE package download
 
-Download ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-4.1pe.exe](https://dist.thingsboard.io/thingsboard-windows-setup-4.1pe.exe).
+Download ThingsBoard PE installation package for Windows: [thingsboard-windows-4.1pe.zip](https://dist.thingsboard.io/thingsboard-windows-4.1pe.zip).
 
 #### ThingsBoard PE service upgrade
 
@@ -388,7 +388,7 @@ net stop thingsboard
 {: .copy-code}
 
 * Make a backup of previous ThingsBoard PE configuration located in \<ThingsBoard install dir\>\conf (for ex. C:\thingsboard\conf).
-* Run installation package **thingsboard-windows-setup-4.1pe.exe**.
+* Copy content of the **thingsboard-windows-4.1pe.zip** to the same location.
 * Compare and merge your old ThingsBoard configuration files (from the backup you made in the first step) with new ones.
 * Finally, run **upgrade.bat** script to upgrade ThingsBoard to the new version.
 
@@ -482,7 +482,7 @@ These upgrade steps are applicable for ThingsBoard version 3.9.xPE and ThingsBoa
 
 #### ThingsBoard PE package download
 
-Download ThingsBoard PE installation package for Windows: [thingsboard-windows-setup-4.0.2pe.exe](https://dist.thingsboard.io/thingsboard-windows-setup-4.0.2pe.exe).
+Download ThingsBoard PE installation package for Windows: [thingsboard-windows-4.0.2pe.zip](https://dist.thingsboard.io/thingsboard-windows-4.0.2pe.zip).
 
 #### ThingsBoard PE service upgrade
 
@@ -494,7 +494,7 @@ net stop thingsboard
 {: .copy-code}
 
 * Make a backup of previous ThingsBoard PE configuration located in \<ThingsBoard install dir\>\conf (for ex. C:\thingsboard\conf).
-* Run installation package **thingsboard-windows-setup-4.0.2pe.exe**.
+* Copy content of the **thingsboard-windows-4.0.2pe.zip** to the same location.
 * Compare and merge your old ThingsBoard configuration files (from the backup you made in the first step) with new ones.
 * Finally, run **upgrade.bat** script to upgrade ThingsBoard to the new version.
 


### PR DESCRIPTION
## PR description

Before:
<img width="1137" height="116" alt="image" src="https://github.com/user-attachments/assets/1e7843d1-1c52-478c-83bc-7990598588db" />

After:
<img width="1137" height="116" alt="image" src="https://github.com/user-attachments/assets/ed4d8351-1833-4fbd-93e1-3741ed91a3d0" />


## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
