### PR TITLE
Add screenshots of Grafana dashboard

### DIFF
--- a/docs/pe/user-guide/troubleshooting.md
+++ b/docs/pe/user-guide/troubleshooting.md
@@ -3,6 +3,30 @@ layout: docwithnav-pe
 title: Troubleshooting
 description: ThingsBoard IoT Platform troubleshooting
 
+metrics-dashboards:
+    0:
+        image: /images/user-guide/troubleshooting/attributes-cache-grafana.png
+        title: 'Statistics about Attributes cache efficiency.'
+    1:
+        image: /images/user-guide/troubleshooting/core-and-js-metrics-grafana.png
+        title: 'Statistics about requests to TB Core and JS processors.'
+    2:
+        image: /images/user-guide/troubleshooting/db-metrics-grafana.png
+        title: 'Statistics about `attributes` and `timeseries` persistence to the PostgreSQL.'
+    3:
+        image: /images/user-guide/troubleshooting/rule-engine-latency-grafana.png
+        title: 'Statistics about time it took to process messages inside of the Rule Engine.'
+    4:
+        image: /images/user-guide/troubleshooting/rule-engine-metrics-grafana.png
+        title: 'Statistics about processing of the message inside of the Rule Engine.'
+    5:
+        image: /images/user-guide/troubleshooting/single-service-metrics-grafana.png
+        title: 'Separate statistics for each service. You can choose the service in the upper left corner.'
+    6:
+        image: /images/user-guide/troubleshooting/transport-metrics-grafana.png
+        title: 'Statistics about messages in Transport services.'
+  
+
 ---
 
 {% assign docsPrefix = "pe/" %}


### PR DESCRIPTION
Added screenshots for the PE troubleshooting page, similar to CE

## PR description

As shown in the screenshots below, now, while the CE documentation correctly includes the dashboard example, the PE page only mentions the screenshot without actually displaying it. 

<img width="1920" height="1041" alt="image" src="https://github.com/user-attachments/assets/1636922d-1564-4fba-b8be-1a981db0c9cd" />

<img width="1920" height="1041" alt="image" src="https://github.com/user-attachments/assets/f44f9efe-0d66-40f0-b370-16ee8163338f" />


This PR updates the PE troubleshooting documentation page to add screenshots with Grafana dashboards, similar to the CE page.