### PR TITLE
Edge randomly disconnects from Cloud

### DIFF
--- a/_includes/templates/edge/troubleshooting/docker-keepalive.md
+++ b/_includes/templates/edge/troubleshooting/docker-keepalive.md
@@ -1,0 +1,35 @@
+#### Server
+Stop the currently running **ThingsBoard** container before making any changes. Then, edit the docker compose file:
+
+```bash
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following lines to the **"environment"** block in the YAML file:
+```yml
+    environment:
+      - EDGES_RPC_CLIENT_MAX_KEEP_ALIVE_TIME_SEC=1
+      - EDGES_RPC_KEEP_ALIVE_TIME_SEC=30
+      - EDGES_RPC_KEEP_ALIVE_TIMEOUT_SEC=25
+```
+{: .copy-code}
+
+#### Edge
+
+Stop the currently running. **TB Edge container** before making any changes. Then, edit the docker compose file:
+
+```bash
+nano docker-compose.yml
+```
+{: .copy-code}
+
+Add the following lines to the **"environment"** block in the YAML file:
+```yml
+    environment:
+      - CLOUD_RPC_KEEP_ALIVE_TIME_SEC=30
+      - CLOUD_RPC_KEEP_ALIVE_TIMEOUT_SEC=25
+```
+{: .copy-code}
+
+Once all the changes have been made, start the **ThingsBoard** and **TB Edge docker containers**.

--- a/_includes/templates/edge/troubleshooting/ubuntu-keepalive.md
+++ b/_includes/templates/edge/troubleshooting/ubuntu-keepalive.md
@@ -1,0 +1,32 @@
+#### Server
+
+Edit the **ThingsBoard configuration file:**
+```bash
+sudo nano /etc/thingsboard/conf/thingsboard.conf
+```
+{: .copy-code}
+
+Add the following lines to the configuration file:
+```bash
+export EDGES_RPC_CLIENT_MAX_KEEP_ALIVE_TIME_SEC=1
+export EDGES_RPC_KEEP_ALIVE_TIME_SEC=30
+export EDGES_RPC_KEEP_ALIVE_TIMEOUT_SEC=25
+```
+{: .copy-code}
+
+#### Edge
+
+Then, edit the **ThingsBoard Edge configuration file:**
+```bash
+sudo nano /etc/tb-edge/conf/tb-edge.conf
+```
+{: .copy-code}
+
+Add the following lines to the configuration file:
+```bash
+export CLOUD_RPC_KEEP_ALIVE_TIME_SEC=30
+export CLOUD_RPC_KEEP_ALIVE_TIMEOUT_SEC=25
+```
+{: .copy-code}
+
+Once all the changes have been made, restart the **ThingsBoard** and **TB Edge services**.


### PR DESCRIPTION
troubleshooting paragraph:
- explains what to do if Edge randomly disconnects from Cloud
- added keepalive configuration parameters to adjust on cloud and edge side
- added brief example on how to apply 


