### PR TITLE
Add advice to use HAProxy for HTTP over SSL doc in specific use cases

### DIFF
--- a/_includes/docs/user-guide/ssl/http-over-ssl.md
+++ b/_includes/docs/user-guide/ssl/http-over-ssl.md
@@ -1,6 +1,13 @@
 * TOC
 {:toc}
 
+{% capture use-haproxy-instead %}
+The best practice for securing your Web UI with HTTPS is to use [HAProxy](/docs/user-guide/install/pe/add-haproxy-ubuntu/), which handles SSL/TLS termination efficiently while protecting user traffic.
+
+However, in some cases you may also need two-way SSL for HTTP transport. If your goal is only HTTPS for the Web UI, go with HAProxy. But if you require two-way SSL for HTTP transport, follow this guide.
+{% endcapture %}
+{% include templates/info-banner.md content=use-haproxy-instead %}
+
 ThingsBoard provides the ability to run HTTP server that hosts Web UI and serves REST API calls over SSL. 
 
 Most of the ThingsBoard environments use the load balancer as a termination point for the SSL connection between the client and the platform.


### PR DESCRIPTION
## PR description

HTTP over SSL documentation did not mention option with HAProxy as SSL-termination method. Since it is a best practice, I added a banner noting that.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
