### PR TITLE
Remove Google forum references

### DIFF
--- a/_includes/docs/edge/troubleshooting.md
+++ b/_includes/docs/edge/troubleshooting.md
@@ -268,10 +268,6 @@ ThingsBoard Edge exposes a set of telemetry keys that allow you to monitor messa
             <span class="phrase-heading">Community chat</span>
             <p>Our Gitter channel is the best way to contact our engineers and share your ideas with them.</p>
         </a>
-        <a href="https://groups.google.com/forum/#!forum/thingsboard">
-            <span class="phrase-heading">Q&A forum</span>
-            <p>Our user forum is a great place to go for community support.</p>
-        </a>
         <a href="https://stackoverflow.com/questions/tagged/thingsboard">
             <span class="phrase-heading">Stack Overflow</span>
             <p>The ThingsBoard team will also monitor posts tagged thingsboard. If there aren’t any existing questions that help, please ask a new one!</p>

--- a/_includes/docs/mqtt-broker/troubleshooting.md
+++ b/_includes/docs/mqtt-broker/troubleshooting.md
@@ -200,10 +200,6 @@ Please note that in order to achieve maximum performance, **TBMQ uses several qu
             <span class="phrase-heading">Community chat</span>
             <p>The best way to contact our engineers and share your ideas with them is through our Gitter channel.</p>
         </a>
-        <a href="https://groups.google.com/forum/#!forum/thingsboard">
-            <span class="phrase-heading">Q&A forum</span>
-            <p>For community support, we recommend visiting our user forum. It's a great place to connect with other users and find solutions to common issues.</p>
-        </a>
         <a href="https://stackoverflow.com/questions/tagged/thingsboard">
             <span class="phrase-heading">Stack Overflow</span>
             <p>The ThingsBoard team actively monitors posts that are tagged with "thingsboard" on the user forum. If you can't find an existing question that addresses your issue, feel free to ask a new one. Our team will be happy to assist you.</p>

--- a/products/thingsboard-pe/aws.md
+++ b/products/thingsboard-pe/aws.md
@@ -294,7 +294,6 @@ redirect_to: "/pricing/"
             <p>
                 Available community resources are listed below:<br>
                 &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://github.com/thingsboard/thingsboard/issues">GitHub issues page</a> - Our GitHub issues page contains a lot of Q&A and discussions about ThingsBoard.<br>
-                &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://groups.google.com/forum/#!forum/thingsboard">Q&A forum</a> - Our user forum is a great place to go for community support.<br>
                 &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://stackoverflow.com/questions/tagged/thingsboard">Stack Overflow</a> - The ThingsBoard team will also monitor posts tagged thingsboard. 
             </p>    
         </div>    


### PR DESCRIPTION
## PR description

The problem: The Edge, PE Edge, and MQTT broker troubleshooting documentation contains URLs that direct users to the Google forum, which is now filled with bots spreading prohibited content (see screenshots below).

<img width="1920" height="1041" alt="image" src="https://github.com/user-attachments/assets/61f5cf0e-7484-4ffa-bc5e-eb2388c4b46f" />
<img width="1920" height="637" alt="image" src="https://github.com/user-attachments/assets/00cb444d-8e12-4723-b4eb-e2620c0f1859" />

This PR removes the Google forum references from the ThingsBoard documentation.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
