### PR TITLE
Rephrase palette description to add theme mention

### DIFF
--- a/_includes/docs/pe/user-guide/white-labeling.md
+++ b/_includes/docs/pe/user-guide/white-labeling.md
@@ -63,13 +63,15 @@ In the "General" tab you can set or change the following options:
 {% endif %}
 
  - Logo height - you can resize the logo;
- - Primary palette - you can customize the background color and font color by choosing one of the suggested UI design options or customizing an existing one;
+ - White labeling allows you to customize the color theme by adjusting the primary and accent palettes to match your desired UI design.
 
-![image](/images/user-guide/white-labeling/primary-palette.png)
+    - Primary palette - you can customize the background col or and font color by choosing one of the suggested UI design options or customizing an existing one;
 
- - Accent palette - you can customize the color for some elements, for example for a toggle;
+    ![image](/images/user-guide/white-labeling/primary-palette.png)
 
-![image](/images/user-guide/white-labeling/accent-palette.png)
+    - Accent palette - you can customize the color for some elements, for example for a toggle;
+
+    ![image](/images/user-guide/white-labeling/accent-palette.png)
 
  - Advanced CSS - you can stylize any elements of the ThingsBoard user interface as you wish. We will talk more about this functionality [below](#advanced-css);
  - Show/hide platform name and version - by checking this option, the name of the platform and its current version will be displayed in the lower left corner.

--- a/_includes/docs/pe/user-guide/white-labeling.md
+++ b/_includes/docs/pe/user-guide/white-labeling.md
@@ -65,7 +65,7 @@ In the "General" tab you can set or change the following options:
  - Logo height - you can resize the logo;
  - White labeling allows you to customize the color theme by adjusting the primary and accent palettes to match your desired UI design.
 
-    - Primary palette - you can customize the background col or and font color by choosing one of the suggested UI design options or customizing an existing one;
+    - Primary palette - you can customize the background color and font color by choosing one of the suggested UI design options or customizing an existing one;
 
     ![image](/images/user-guide/white-labeling/primary-palette.png)
 


### PR DESCRIPTION
## PR description

The problem: When a customer asked the chatbot if ThingsBoard provides theme customization, the chatbot returned an irrelevant response.
This PR rephrases the palette description to explicitly mention theme customization.

How it was: 
<img width="1920" height="1039" alt="image" src="https://github.com/user-attachments/assets/0f388069-fc13-4b9b-b401-85947bbdcb78" />

How it became: 
<img width="1920" height="1039" alt="image" src="https://github.com/user-attachments/assets/f0ea217c-be56-493f-8de0-5a3368883fcf" />


## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
