### PR TITLE
Fix: Update Formspree fields to be compatible with Pipedrive

### DIFF
--- a/_includes/contact-us-modal.html
+++ b/_includes/contact-us-modal.html
@@ -31,14 +31,14 @@
             <fieldset>
                 <div class="form-section">
                     <div class="form-element">
-                        <label for="first-name">
-                            <input class="form-control" value="" placeholder="John" name="first-name" id="first-name" type="text" size="40" maxlength="50" aria-invalid="false">
+                        <label for="firstName">
+                            <input class="form-control" value="" placeholder="John" name="firstName" id="firstName" type="text" size="40" maxlength="50" aria-invalid="false">
                             <p>First Name</p>
                         </label>
                     </div>
                     <div class="form-element">
-                        <label for="last-name">
-                            <input class="form-control" value="" placeholder="Doe" name="last-name" id="last-name" type="text" size="40" maxlength="50" aria-invalid="false">
+                        <label for="lastName">
+                            <input class="form-control" value="" placeholder="Doe" name="lastName" id="lastName" type="text" size="40" maxlength="50" aria-invalid="false">
                             <p>Last Name</p>
                         </label>
                     </div>
@@ -106,7 +106,7 @@
         const form = document.getElementById('ContactUs');
 
         const fieldsToWatchForInput = [
-            'first-name', 'last-name', 'email', 'company', 'message'
+            'firstName', 'lastName', 'email', 'company', 'message'
         ];
 
         fieldsToWatchForInput.forEach(fieldName => {
@@ -209,8 +209,8 @@
     function validateContactForm(form) {
         let isValid = true;
         const fieldsToValidate = [
-            { name: 'first-name', prettyName: 'First Name', type: 'text', id: 'first-name' },
-            { name: 'last-name', prettyName: 'Last Name', type: 'text', id: 'last-name' },
+            { name: 'firstName', prettyName: 'First Name', type: 'text', id: 'firstName' },
+            { name: 'lastName', prettyName: 'Last Name', type: 'text', id: 'lastName' },
             { name: 'email', prettyName: 'Email Address', type: 'email', id: 'email' },
             { name: 'company', prettyName: 'Company', type: 'text', id: 'company' },
             { name: 'message', prettyName: 'Message', type: 'textarea', id: 'message' }

--- a/docs/contact-us.md
+++ b/docs/contact-us.md
@@ -82,8 +82,8 @@ notitle: "true"
     function validateContactForm(form) {
         let isValid = true;
         const fieldsToValidate = [
-            { name: 'first-name', prettyName: 'First Name', type: 'text', id: 'first-name' },
-            { name: 'last-name', prettyName: 'Last Name', type: 'text', id: 'last-name' },
+            { name: 'firstName', prettyName: 'First Name', type: 'text', id: 'firstName' },
+            { name: 'lastName', prettyName: 'Last Name', type: 'text', id: 'lastName' },
             { name: 'email', prettyName: 'Email Address', type: 'email', id: 'email' },
             { name: 'company', prettyName: 'Company', type: 'text', id: 'company' },
             { name: 'message', prettyName: 'Message', type: 'textarea', id: 'message' }
@@ -127,7 +127,7 @@ notitle: "true"
         const form = document.getElementById('ContactUs');
 
         const fieldsToWatchForInput = [
-            'first-name', 'last-name', 'email', 'company', 'message'
+            'firstName', 'lastName', 'email', 'company', 'message'
         ];
 
         fieldsToWatchForInput.forEach(fieldName => {
@@ -147,14 +147,14 @@ notitle: "true"
     <fieldset>
         <div class="form-section">
             <div class="form-element">
-                <label for="first-name">
-                   <input class="form-control" value="" placeholder="John" name="first-name" id="first-name" type="text" size="40" maxlength="50" aria-invalid="false">
+                <label for="firstName">
+                   <input class="form-control" value="" placeholder="John" name="firstName" id="firstName" type="text" size="40" maxlength="50" aria-invalid="false">
                     <p>First Name</p>
                 </label>
             </div>
             <div class="form-element">
-                <label for="last-name">
-                    <input class="form-control" value="" placeholder="Doe" name="last-name" id="last-name" type="text" size="40" maxlength="50" aria-invalid="false">
+                <label for="lastName">
+                    <input class="form-control" value="" placeholder="Doe" name="lastName" id="lastName" type="text" size="40" maxlength="50" aria-invalid="false">
                     <p>Last Name</p>
                 </label>
             </div>

--- a/services/development-services/customers-full-reviews.md
+++ b/services/development-services/customers-full-reviews.md
@@ -128,8 +128,8 @@ redirect_from: "docs/services/customers-full-reviews/"
         <form id="contact-form" method="post" onsubmit="return validateContactForm(this)">
             <div class="form-section">
                 <div class="form-element">
-                    <label for="first-name">
-                        <input id="first-name" class="cdu-form-control" value="" placeholder="Your Name" name="first-name" type="text" size="40" maxlength="50">
+                    <label for="name">
+                        <input id="name" class="cdu-form-control" value="" placeholder="Your Name" name="name" type="text" size="40" maxlength="50">
                         <p>Name*</p>
                     </label>
                 </div>
@@ -196,7 +196,7 @@ redirect_from: "docs/services/customers-full-reviews/"
     }
 
     function validateContactForm(form) {
-        var name = $('input[name=first-name]', form).val();
+        var name = $('input[name=name]', form).val();
         var email = $('input[name=email]', form).val();
 
         if (!validateValue('Name', name)) {

--- a/services/development-services/index.md
+++ b/services/development-services/index.md
@@ -1299,8 +1299,8 @@ description: "Fast delivery of scalable IoT solutions with fixed cost and timeli
                             class="gtm_form developmentServicesContactUsForm">
                             <div class="form-section">
                                 <div class="form-element">
-                                    <label for="first-name">
-                                        <input id="first-name" class="form-control cdu-form-control" value="" placeholder="Your Name" name="first-name" type="text" size="40" maxlength="50">
+                                    <label for="name">
+                                        <input id="name" class="form-control cdu-form-control" value="" placeholder="Your Name" name="name" type="text" size="40" maxlength="50">
                                         <p>Name*</p>
                                     </label>
                                 </div>
@@ -1405,14 +1405,14 @@ description: "Fast delivery of scalable IoT solutions with fixed cost and timeli
             <div class="sub-content">
                 <div class="form-section">
                     <div class="form-element">
-                        <label for="first-name">
-                            <input id="first-name-popup" class="form-control cdu-form-control" value="" placeholder="Your Name" name="first-name-popup" type="text" size="40" maxlength="50">
+                        <label for="name">
+                            <input id="name" class="form-control cdu-form-control" value="" placeholder="Your Name" name="name" type="text" size="40" maxlength="50">
                             <p>Name*</p>
                         </label>
                     </div>
                     <div class="form-element">
                         <label for="email">
-                            <input id="email-popup" class="form-control cdu-form-control" value="" placeholder="Enter Email" name="email-popup" type="email" size="40" maxlength="80">
+                            <input id="email" class="form-control cdu-form-control" value="" placeholder="Enter Email" name="email" type="email" size="40" maxlength="80">
                             <p>Email Address*</p>
                         </label>
                     </div>
@@ -2034,8 +2034,8 @@ description: "Fast delivery of scalable IoT solutions with fixed cost and timeli
     })();
 
     function validateContactForm(form) {
-        var name = $('input[name=first-name]', form).val() || $('input[name=first-name-popup]', form).val();
-        var email = $('input[name=email]', form).val() || $('input[name=email-popup]', form).val();
+        var name = $('input[name=name]', form).val();
+        var email = $('input[name=email]', form).val();
 
         if (!validateValue('Name', name)) {
             return false;

--- a/smart-farming-demo.md
+++ b/smart-farming-demo.md
@@ -193,8 +193,8 @@ notitle: "true"
         <form id="contact-form" method="post" onsubmit="return validateContactForm(this)">
             <div class="form-section">
                 <div class="form-element">
-                    <label for="first-name">
-                        <input id="first-name" class="cdu-form-control" value="" placeholder="Your Name" name="first-name" type="text" size="40" maxlength="50">
+                    <label for="name">
+                        <input id="name" class="cdu-form-control" value="" placeholder="Your Name" name="name" type="text" size="40" maxlength="50">
                         <p>Name*</p>
                     </label>
                 </div>
@@ -300,7 +300,7 @@ notitle: "true"
     });
 
     function validateContactForm(form) {
-        var name = $('input[name=first-name]', form).val();
+        var name = $('input[name=name]', form).val();
         var email = $('input[name=email]', form).val();
         var message = $('textarea[name=message]', form).val();
 


### PR DESCRIPTION
## PR description

This PR updates the form fields used in the website integration between **Formspree** and **Pipedrive**.  
The issue was that Pipedrive only supports the following field names for contact creation:
- 'email' **(required)**
- 'name'
- 'lastName'
- 'firstName'

Previously, the form used fields like 'first-name' and 'last-name', which are **not recognized by Pipedrive**, causing form submissions to fail or lead to incomplete records.

- Replaced 'first-name' with 'firstName' or 'name'
- Replaced 'last-name' with 'lastName`
- Replaced 'first-name-popup' with 'name'
- Replaced 'email-popup' with 'email'
- Ensured compatibility with Pipedrive’s expected schema for contact data.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
