### PR TITLE
Delete stress test pages with no content

### DIFF
--- a/_data/pages_info.yml
+++ b/_data/pages_info.yml
@@ -3846,12 +3846,6 @@
 "/docs/private-cloud/subscription/":
   url: "/docs/private-cloud/subscription/"
   redirect_from: []
-"/docs/reference/1m-devices-test/":
-  url: "/docs/reference/1m-devices-test/"
-  redirect_from: []
-"/docs/reference/20k-devices-test/":
-  url: "/docs/reference/20k-devices-test/"
-  redirect_from: []
 "/docs/reference/actions/kafka-plugin-action/":
   url: "/docs/reference/actions/kafka-plugin-action/"
   redirect_from: []

--- a/docs/reference/1m-devices-test.md
+++ b/docs/reference/1m-devices-test.md
@@ -1,6 +1,0 @@
----
-layout: docwithnav
-title: 1M IoT devices on ThingsBoard cluster with Kubernetes and Amazon EC2
-description: Overview of performance scenario and metrics 
-
----

--- a/docs/reference/20k-devices-test.md
+++ b/docs/reference/20k-devices-test.md
@@ -1,6 +1,0 @@
----
-layout: docwithnav
-title: 20K IoT devices on single ThingsBoard instance
-description: Overview of performance scenario and metrics 
-
----


### PR DESCRIPTION
## PR description

Issue:
The ThingsBoard CE documentation contains stress test pages that have no content.

<img width="1920" height="1043" alt="image" src="https://github.com/user-attachments/assets/bf6f97ee-60b2-4fe9-b311-1af2d9ceba20" />

This PR removes the empty stress test pages from the project and also deletes their references from pages_info.yml.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
