### PR TITLE
Adding note that Downlink Converters are optional

### DIFF
--- a/_includes/docs/pe/user-guide/integrations/index.md
+++ b/_includes/docs/pe/user-guide/integrations/index.md
@@ -215,6 +215,11 @@ Example of converter output data:
 
 The main function of **downlink data converter** is to transform the incoming rule engine message and its metadata to the format that is used by corresponding Integration.
 
+{% capture difference %}
+**NOTE**: A Downlink Converter is generally optional. It is required only if your integration needs ThingsBoard to send outgoing messages, such as RPCs, attribute updates, or other commands. If your integration only involves receiving data without initiating outbound communication, you can skip creating a Downlink Converter.
+{% endcapture %}
+{% include templates/info-banner.md content=difference %}
+
 To create the Downlink data converter, follow these steps:
 - Navigate to the "**Data converters**" section in the "**Integration center**", click the "**plus**" icon button, and In the dropdown menu, select "**Create new converter**".
 - In the new window:


### PR DESCRIPTION
## PR description

This PR adds an info note indicating that Downlink Converters are generally optional.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
