### PR TITLE
fix redirects for SQS and Gateway

### DIFF
--- a/_data/pages_info.yml
+++ b/_data/pages_info.yml
@@ -643,8 +643,8 @@
 "/docs/iot-gateway/guides/how-to-connect-modbus-device/":
   url: "/docs/iot-gateway/guides/how-to-connect-modbus-device/"
   redirect_from: []
-"/docs/iot-gateway/guides/how-to-connect-opcua-server/":
-  url: "/docs/iot-gateway/guides/how-to-connect-opcua-server/"
+"/docs/iot-gateway/guides/how-to-connect-opc-ua-device-to-thingsboard-ce/":
+  url: "/docs/iot-gateway/guides/how-to-connect-opc-ua-device-to-thingsboard-ce/"
   redirect_from: []
 "/docs/iot-gateway/guides/how-to-enable-remote-configuration/":
   url: "/docs/iot-gateway/guides/how-to-enable-remote-configuration/"
@@ -666,9 +666,6 @@
   redirect_from: []
 "/docs/iot-gateway/guides/how-to-use-remote-converter-update/":
   url: "/docs/iot-gateway/guides/how-to-use-remote-converter-update/"
-  redirect_from: []
-"/docs/iot-gateway/guides/how-to-use-rpc-modbus-connector/":
-  url: "/docs/iot-gateway/guides/how-to-use-rpc-modbus-connector/"
   redirect_from: []
 "/docs/iot-gateway/how-device-removing-renaming-works/":
   url: "/docs/iot-gateway/how-device-removing-renaming-works/"
@@ -5070,7 +5067,7 @@
 "/docs/user-guide/rule-engine-2-0/nodes/external/aws-sqs/":
   url: "/docs/user-guide/rule-engine-2-0/nodes/external/aws-sqs/"
   redirect_from:
-  - "/reference/plugins/sqs/"
+  - "/docs/reference/plugins/sqs/"
 "/docs/user-guide/rule-engine-2-0/nodes/external/azure-iot-hub/":
   url: "/docs/user-guide/rule-engine-2-0/nodes/external/azure-iot-hub/"
   redirect_from: []

--- a/_data/pages_redirect_info.yml
+++ b/_data/pages_redirect_info.yml
@@ -401,9 +401,9 @@
 "/docs/reference/plugins/sns/":
   url: "/docs/user-guide/rule-engine-2-0/nodes/external/aws-sns/"
   redirect_from: "/docs/reference/plugins/sns/"
-"/reference/plugins/sqs/":
+"/docs/reference/plugins/sqs/":
   url: "/docs/user-guide/rule-engine-2-0/nodes/external/aws-sqs/"
-  redirect_from: "/reference/plugins/sqs/"
+  redirect_from: "/docs/reference/plugins/sqs/"
 "/docs/user-guide/rule-engine-2-0/external-nodes/":
   url: "/docs/user-guide/rule-engine-2-0/nodes/external/"
   redirect_from: "/docs/user-guide/rule-engine-2-0/external-nodes/"

--- a/docs/user-guide/rule-engine-2-0/nodes/external/aws-sqs.md
+++ b/docs/user-guide/rule-engine-2-0/nodes/external/aws-sqs.md
@@ -5,7 +5,7 @@ description: Publishes messages to the AWS SQS (Amazon Simple Queue Service).
 breadcrumbs: "true"
 breadcrumbs-steps: "2"
 hidetoc: "true"
-redirect_from: "/reference/plugins/sqs/"
+redirect_from: "/docs/reference/plugins/sqs/"
 ---
 
 {% include get-hosts-name.html %}


### PR DESCRIPTION
## PR description

Fixed typo in link for redirecting outdated SQS plugin guide to SQS rule node.
Additionally, when generating site, some Gateway links were fixed with auto-generated redirect YAML file - they are also included in this PR.

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
