### PR TITLE
Improve data retention description

### DIFF
--- a/_includes/docs/user-guide/telemetry.md
+++ b/_includes/docs/user-guide/telemetry.md
@@ -154,7 +154,7 @@ See [Save Timeseries rule node](/docs/user-guide/rule-engine-2-0/nodes/action/sa
 **Note:** Retention settings follow a priority order (highest to lowest):  
 1. Message metadata `TTL` property   
 2. Rule node configuration   
-3. Tenant Profile configuration or Tenant Attribute
+3. Tenant Profile configuration (Cassandra) or Tenant Attribute (PostgreSQL/TimescaleDB)
 4. System-wide configuration
 {% endcapture %}
 {% include templates/info-banner.md content=internal_data_format %}


### PR DESCRIPTION
## PR description

This PR updates the documentation for the ThingsBoard data retention policy. The current version does not provide a detailed explanation of the available features.

This PR improves the data retention section to make the explanation clearer.

How it was:
<img width="1917" height="1040" alt="image" src="https://github.com/user-attachments/assets/6f2618e6-85b1-4016-b1a3-68249c6b8457" />

How it became:
<img width="1917" height="1040" alt="image" src="https://github.com/user-attachments/assets/b60080c4-b88f-48f7-9ef6-0cb969dfced1" />

## Link checker

The links will be checked by the build agent automatically once you create or update your PR.

You can use the following command to check the broken links locally.

```bash
docker run --rm -it --network=host --name=linkchecker ghcr.io/linkchecker/linkchecker --check-extern --no-warnings http://0.0.0.0:4000/
```
