### PR TITLE
Fix redirect issue for security settings page

### DIFF
--- a/_data/pages_info.yml
+++ b/_data/pages_info.yml
@@ -690,6 +690,9 @@
 "/docs/iot-gateway/guides/how-to-use-remote-converter-update/":
   url: "/docs/iot-gateway/guides/how-to-use-remote-converter-update/"
   redirect_from: []
+"/docs/iot-gateway/guides/how-to-use-rpc-modbus-connector/":
+  url: "/docs/iot-gateway/guides/how-to-use-rpc-modbus-connector/"
+  redirect_from: []
 "/docs/iot-gateway/how-device-removing-renaming-works/":
   url: "/docs/iot-gateway/how-device-removing-renaming-works/"
   redirect_from: []
@@ -3894,7 +3897,8 @@
   redirect_from: []
 "/docs/pe/user-guide/ui/security-settings/":
   url: "/docs/pe/user-guide/ui/security-settings/"
-  redirect_from: []
+  redirect_from:
+  - "/docs/pe/user-guide/ui/jwt-security-settings/"
 "/docs/pe/user-guide/ui/slack-settings/":
   url: "/docs/pe/user-guide/ui/slack-settings/"
   redirect_from: []
@@ -5466,7 +5470,6 @@
 "/docs/user-guide/ui/security-settings/":
   url: "/docs/user-guide/ui/security-settings/"
   redirect_from:
-  - "/docs/pe/user-guide/ui/jwt-security-settings/"
   - "/docs/user-guide/ui/jwt-security-settings/"
 "/docs/user-guide/ui/slack-settings/":
   url: "/docs/user-guide/ui/slack-settings/"

--- a/_data/pages_redirect_info.yml
+++ b/_data/pages_redirect_info.yml
@@ -275,6 +275,9 @@ docs/pe/user-guide/contribution/widgets-development-before-3.0/:
 "/docs/pe/user-guide/ui/tenant-profiles":
   url: "/docs/pe/user-guide/tenant-profiles/"
   redirect_from: "/docs/pe/user-guide/ui/tenant-profiles"
+"/docs/pe/user-guide/ui/jwt-security-settings/":
+  url: "/docs/pe/user-guide/ui/security-settings/"
+  redirect_from: "/docs/pe/user-guide/ui/jwt-security-settings/"
 "/docs/pe/user-guide/ui/widgets/trip-animation-widget/":
   url: "/docs/pe/user-guide/ui/trip-animation-widget/"
   redirect_from: "/docs/pe/user-guide/ui/widgets/trip-animation-widget/"
@@ -509,9 +512,6 @@ docs/user-guide/contribution/widgets-development-before-3.0/:
 "/docs/samples/alarms/mail/":
   url: "/docs/user-guide/ui/mail-settings/"
   redirect_from: "/docs/samples/alarms/mail/"
-"/docs/pe/user-guide/ui/jwt-security-settings/":
-  url: "/docs/user-guide/ui/security-settings/"
-  redirect_from: "/docs/pe/user-guide/ui/jwt-security-settings/"
 "/docs/user-guide/ui/jwt-security-settings/":
   url: "/docs/user-guide/ui/security-settings/"
   redirect_from: "/docs/user-guide/ui/jwt-security-settings/"

--- a/docs/user-guide/ui/security-settings.md
+++ b/docs/user-guide/ui/security-settings.md
@@ -6,7 +6,7 @@ title: Security settings
 description: ThingsBoard IoT platform security settings
 
 redirect_from: 
-    - "/docs/pe/user-guide/ui/jwt-security-settings/"
+    - "/docs/user-guide/ui/jwt-security-settings/"
 
 ---
 


### PR DESCRIPTION
## Description

This PR fixes a 404 redirect issue for the Security page: [JWT Security Settings](https://thingsboard.io/docs/user-guide/ui/jwt-security-settings/)

## Changes

- Corrected a typo in the documentation security settings page that caused the page to return a 404 error when accessed. 
<img width="1876" height="418" alt="image" src="https://github.com/user-attachments/assets/0231f22b-50f9-416e-ba9a-3165810fccf1" />

- The following entry in `pages_info.yml` was added when auto-generating site info (it might have been missing from some previous commits)
```yml
"/docs/iot-gateway/guides/how-to-use-rpc-modbus-connector/":
  url: "/docs/iot-gateway/guides/how-to-use-rpc-modbus-connector/"
  redirect_from: []
```
